### PR TITLE
Fix PS4 startup instability from uninit thread pool and reinjection r…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,10 +233,10 @@ test-zero-copy: src/util/lz4.c tests/test_zero_copy.c tests/bench_utils.h
 	@echo "--- Running Zero-Copy Benchmarks ---"
 	$(BUILD_DIR)/test_zero_copy
 
-test-thread-pool: tests/test_thread_pool.c
+test-thread-pool: tests/test_thread_pool.c $(GENERATED_VERSION_HEADER)
 	@mkdir -p $(BUILD_DIR)
 	$(HOST_CC) $(HOST_CPPFLAGS) $(HOST_CFLAGS) tests/test_thread_pool.c $(HOST_LDFLAGS) $(HOST_LDLIBS) -o $(BUILD_DIR)/test_thread_pool
-	@echo "--- Running Dynamic Thread Pool test ---"
+	@echo "--- Running thread pool implementation test ---"
 	$(BUILD_DIR)/test_thread_pool
 
 test-max-connections-e2e: host tests/test_max_connections_e2e.c

--- a/include/memdbg/daemon/thread_pool.h
+++ b/include/memdbg/daemon/thread_pool.h
@@ -34,9 +34,10 @@ memdbg_thread_pool_t *memdbg_thread_pool_create(unsigned int num_workers);
 
 /*
  * Enqueue a connection for handling by an available worker.
- * `args` ownership transfers to the pool — it is freed by the
- * worker after connection_handler_thread() returns.
- * Returns 0 on success, -1 if the pool is shutting down.
+ * On success, `args` ownership transfers to the pool and it is freed by the
+ * worker after connection_handler_thread() returns. On failure, ownership
+ * remains with the caller.
+ * Returns 0 on success, -1 if allocation fails or the pool is shutting down.
  */
 int memdbg_thread_pool_enqueue(memdbg_thread_pool_t *pool,
                                connection_args_t *args);

--- a/src/core/daemon/daemon_main.c
+++ b/src/core/daemon/daemon_main.c
@@ -51,6 +51,7 @@
 #if defined(PLATFORM_PS4) || defined(PS4) || defined(__ORBIS__)
 #include <ps4/klog.h>
 #define MEMDBG_DAEMON_CONSOLE 1
+#define MEMDBG_DAEMON_PS4 1
 #elif defined(PLATFORM_PS5) || defined(PS5) || defined(__PROSPERO__)
 #include <ps5/klog.h>
 #include <sys/reboot.h>
@@ -68,8 +69,20 @@ extern void memdbg_beacon_stop(void);
 /* ---- Globals ---- */
 
 static atomic_bool g_stop_requested = false;
+static atomic_bool g_daemon_entry_active = ATOMIC_VAR_INIT(false);
 atomic_uint g_active_connections = 0;
 uint64_t    g_start_ticks = 0;
+
+static bool daemon_entry_try_acquire(void) {
+  bool expected = false;
+  return atomic_compare_exchange_strong_explicit(
+      &g_daemon_entry_active, &expected, true,
+      memory_order_acquire, memory_order_relaxed);
+}
+
+static void daemon_entry_release(void) {
+  atomic_store_explicit(&g_daemon_entry_active, false, memory_order_release);
+}
 
 /* ---- Config ---- */
 
@@ -270,26 +283,39 @@ int memdbg_daemon_run(const memdbg_config_t *cfg_in) {
   if (cfg_in == NULL) memdbg_config_defaults(&cfg);
   else                cfg = *cfg_in;
 
+  /* GoldHEN can invoke the ELF entry point again inside the same loader
+   * process while the first invocation is still starting or running.  Do not
+   * reset shared stop/log/socket state from that concurrent entry. */
+  if (!daemon_entry_try_acquire())
+    return MEMDBG_OK;
+
   atomic_store_explicit(&g_stop_requested, false, memory_order_relaxed);
   g_start_ticks = monotonic_seconds();
 
-  if (pal_network_init() != 0) return MEMDBG_ERR_NET;
+  if (pal_network_init() != 0) {
+    daemon_entry_release();
+    return MEMDBG_ERR_NET;
+  }
 
   /* A second GoldHEN injection may execute inside the same process.  Detect
    * it as early as possible, before touching shared log, UDP, or listener
    * state.  The TCP ping needs the network subsystem, but logging must stay
    * uninitialised so a live daemon keeps its log sinks. */
   if (memdbg_instance_is_current_process(&cfg)) {
+#if !defined(MEMDBG_DAEMON_PS4)
     if (pal_notification_init() == 0) {
       pal_notification_send("MemDBG is already running");
       pal_notification_shutdown();
     }
+#endif
     (void)pal_network_fini();
+    daemon_entry_release();
     return MEMDBG_OK;
   }
 
   if (memdbg_log_init(cfg.data_root) != 0) {
     (void)pal_network_fini();
+    daemon_entry_release();
     return MEMDBG_ERR_IO;
   }
   int notification_ready = (pal_notification_init() == 0);
@@ -331,6 +357,7 @@ int memdbg_daemon_run(const memdbg_config_t *cfg_in) {
     memdbg_udp_log_stop();
     memdbg_log_close();
     pal_network_fini();
+    daemon_entry_release();
     return MEMDBG_ERR_NET;
   }
 
@@ -495,5 +522,6 @@ shutdown_cleanup:
   memdbg_udp_log_stop();
   memdbg_log_close();
   pal_network_fini();
+  daemon_entry_release();
   return MEMDBG_OK;
 }

--- a/src/core/daemon/thread_pool.c
+++ b/src/core/daemon/thread_pool.c
@@ -84,6 +84,7 @@ memdbg_thread_pool_t *memdbg_thread_pool_create(unsigned int num_workers) {
   memdbg_thread_pool_t *pool = NULL;
   if (posix_memalign((void **)&pool, 64, sizeof(*pool)) != 0)
     return NULL;
+  memset(pool, 0, sizeof(*pool));
 
   pool->num_workers = num_workers;
   pool->workers = (pthread_t *)calloc(num_workers, sizeof(pthread_t));
@@ -128,13 +129,11 @@ int memdbg_thread_pool_enqueue(memdbg_thread_pool_t *pool,
 
   /* Reject if shutting down. */
   if (atomic_load_explicit(&pool->shutting_down, memory_order_acquire)) {
-    free(args);
     return -1;
   }
 
   work_node_t *node = (work_node_t *)malloc(sizeof(*node));
   if (node == NULL) {
-    free(args);
     return -1;
   }
   node->args = args;
@@ -145,7 +144,6 @@ int memdbg_thread_pool_enqueue(memdbg_thread_pool_t *pool,
   /* Double-check shutdown under lock. */
   if (atomic_load_explicit(&pool->shutting_down, memory_order_acquire)) {
     pthread_mutex_unlock(&pool->queue_mtx);
-    free(args);
     free(node);
     return -1;
   }

--- a/tests/test_thread_pool.c
+++ b/tests/test_thread_pool.c
@@ -1,364 +1,162 @@
 /*
- * memDBG - Dynamic thread pool unit test.
+ * memDBG - Thread pool implementation tests.
  * Copyright (C) 2026 SeregonWar
  * SPDX-License-Identifier: GPL-3.0-or-later
  *
- * Tests the acceptor/handler connection model:
- * - Single acceptor thread with poll-based accept polling
- * - Per-connection detached handler threads
- * - max_connections cap enforcement
- * - No connection count leaks on shutdown
- * - Concurrent client connect/rejection correctness
+ * Include the implementation directly so the test can verify that every
+ * field read by newly started workers is initialized before pthread_create.
  */
 
-#include <arpa/inet.h>
-#include <errno.h>
-#include <fcntl.h>
-#include <netinet/in.h>
-#include <poll.h>
-#include <pthread.h>
-#include <signal.h>
+#include <stdarg.h>
 #include <stdatomic.h>
-#include <stdbool.h>
-#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/socket.h>
-#include <sys/time.h>
 #include <time.h>
-#include <unistd.h>
 
-/* ---- Test configuration ---- */
+#include "../src/core/daemon/thread_pool.c"
 
-#define MAX_CONNECTIONS  4   /* accept cap under test */
-#define CLIENT_COUNT     8   /* total concurrent connects (> cap) */
-#define CONNECT_TIMEOUT_S 3  /* per-connect timeout */
-#define POLL_MS           10 /* acceptor poll interval (ms) */
-#define HANDLER_SLEEP_MS  100 /* simulated work per handler */
+#define TEST_WORKERS 4U
+#define TEST_TASKS 64U
+#define TEST_INIT_ITERATIONS 32U
+#define TEST_TIMEOUT_MS 5000U
 
-/* ---- Shared state ---- */
+static atomic_uint g_handled = ATOMIC_VAR_INIT(0U);
+static int g_failed = 0;
 
-/* Zero-initialized by virtue of being static / file-scope. */
-static atomic_uint g_active_connections;
-static atomic_bool  g_stop_requested;
-static atomic_int   g_accepted_count;
-static atomic_int   g_rejected_count;
-static atomic_int   g_connected_count;
-
-/* ---- Minimal random port binding ---- */
-
-static int bind_any_port(uint16_t *out_port) {
-  int fd = socket(AF_INET, SOCK_STREAM, 0);
-  if (fd < 0) { perror("socket"); return -1; }
-
-  int opt = 1;
-  setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
-
-  struct sockaddr_in addr = {0};
-  addr.sin_family = AF_INET;
-  addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
-  addr.sin_port = 0; /* any port */
-
-  if (bind(fd, (struct sockaddr *)&addr, sizeof(addr)) != 0) {
-    perror("bind"); close(fd); return -1;
-  }
-
-  if (listen(fd, 16) != 0) {
-    perror("listen"); close(fd); return -1;
-  }
-
-  socklen_t len = sizeof(addr);
-  if (getsockname(fd, (struct sockaddr *)&addr, &len) != 0) {
-    perror("getsockname"); close(fd); return -1;
-  }
-
-  *out_port = ntohs(addr.sin_port);
-  return fd;
+void memdbg_log_write(memdbg_log_level_t level, const char *fmt, ...) {
+  (void)level;
+  (void)fmt;
 }
 
-/* ---- Per-connection handler (simulates handle_client) ---- */
+int pal_socket_close(socket_t fd) {
+  (void)fd;
+  return 0;
+}
 
-typedef struct {
-  int client_fd;
-} handler_args_t;
-
-static void *handler_thread(void *arg) {
-  handler_args_t *hargs = (handler_args_t *)arg;
-  int fd = hargs->client_fd;
-  free(hargs);
-
-  /* Simulate processing (e.g. HELLO, protocol loop, etc.) */
-  {
-    struct timespec ts = { .tv_sec = 0, .tv_nsec = (long)HANDLER_SLEEP_MS * 1000000L };
-    nanosleep(&ts, NULL);
-  }
-
-  /* Close the fd — handle_client does pal_socket_close() */
-  close(fd);
-
-  atomic_fetch_sub_explicit(&g_active_connections, 1U, memory_order_relaxed);
+void *connection_handler_thread(void *arg) {
+  connection_args_t *args = (connection_args_t *)arg;
+  free(args);
+  atomic_fetch_add_explicit(&g_handled, 1U, memory_order_release);
   return NULL;
 }
 
-/* Arguments passed to the acceptor thread.  Mirrors daemon's acceptor_args_t. */
-typedef struct {
-  int listen_fd;
-} acceptor_args_t;
-
-/* ---- Acceptor thread (mirrors daemon's acceptor_thread) ---- */
-
-static void *acceptor_thread(void *arg) {
-  acceptor_args_t *aargs = (acceptor_args_t *)arg;
-  int listen_fd = aargs->listen_fd;
-  free(aargs);
-
-  while (!atomic_load_explicit(&g_stop_requested, memory_order_relaxed)) {
-    /* Poll with short timeout (simulates epoll_wait/kevent with 1ms). */
-    struct pollfd pfd;
-    pfd.fd     = listen_fd;
-    pfd.events = POLLIN;
-    int rc = poll(&pfd, 1, POLL_MS);
-    if (rc < 0) {
-      if (errno == EINTR) continue;
-      break;
-    }
-    if (rc == 0) continue; /* timeout — check stop flag */
-
-    struct sockaddr_in peer;
-    socklen_t slen = sizeof(peer);
-    int client_fd = accept(listen_fd, (struct sockaddr *)&peer, &slen);
-    if (client_fd < 0) {
-      if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK)
-        continue;
-      break;
-    }
-
-    /* Enforce the connection cap: accept first to drain the TCP backlog,
-     * then reject if over limit.  This mirrors the daemon's logic. */
-    uint32_t active = atomic_load_explicit(&g_active_connections,
-                                            memory_order_acquire);
-    if (active >= MAX_CONNECTIONS) {
-      atomic_fetch_add_explicit(&g_rejected_count, 1, memory_order_relaxed);
-      close(client_fd);
-      continue;
-    }
-
-    atomic_fetch_add_explicit(&g_active_connections, 1U, memory_order_relaxed);
-    atomic_fetch_add_explicit(&g_accepted_count, 1, memory_order_relaxed);
-
-    /* Spawn detached handler. */
-    handler_args_t *hargs = (handler_args_t *)malloc(sizeof(*hargs));
-    if (hargs == NULL) {
-      fprintf(stderr, "  ERROR: malloc handler args failed\n");
-      close(client_fd);
-      atomic_fetch_sub_explicit(&g_active_connections, 1U, memory_order_relaxed);
-      continue;
-    }
-    hargs->client_fd = client_fd;
-
-    pthread_t tid;
-    if (pthread_create(&tid, NULL, handler_thread, hargs) != 0) {
-      fprintf(stderr, "  ERROR: pthread_create handler failed\n");
-      free(hargs);
-      close(client_fd);
-      atomic_fetch_sub_explicit(&g_active_connections, 1U, memory_order_relaxed);
-      continue;
-    }
-    pthread_detach(tid);
-  }
-
-  return NULL;
-}
-
-/* ---- Client thread ---- */
-
-static int g_port = 0; /* set before client threads start */
-
-static void *client_thread(void *arg) {
-  (void)arg;
-
-  int fd = socket(AF_INET, SOCK_STREAM, 0);
-  if (fd < 0) { perror("client socket"); return NULL; }
-
-  struct sockaddr_in addr = {0};
-  addr.sin_family = AF_INET;
-  addr.sin_port   = htons((uint16_t)g_port);
-  inet_pton(AF_INET, "127.0.0.1", &addr.sin_addr);
-
-  /* Set connect timeout. */
-  struct timeval tv = { CONNECT_TIMEOUT_S, 0 };
-  setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
-
-  int rc = connect(fd, (struct sockaddr *)&addr, sizeof(addr));
-  if (rc != 0) {
-    /* Connection refused — expected for rejected clients. */
-    close(fd);
-    return NULL;
-  }
-
-  /* The client got past connect().  The handler may close the fd
-   * shortly, but we've verified the connection was accepted. */
-  atomic_fetch_add_explicit(&g_connected_count, 1, memory_order_relaxed);
-
-  /* Sleep briefly so the handler has time to process and close. */
-  {
-    struct timespec ts = { .tv_sec = 0, .tv_nsec = 200 * 1000000L };
-    nanosleep(&ts, NULL);
-  }
-
-  /* Attempt a write — should fail with EPIPE if the handler already
-   * closed the fd (expected for accepted clients). */
-  (void)send(fd, "x", 1, 0);
-
-  close(fd);
-  return NULL;
-}
-
-/* ---- Monotonic time helper ---- */
-
-static uint64_t now_ms(void) {
-  struct timespec ts;
-  clock_gettime(CLOCK_MONOTONIC, &ts);
-  return (uint64_t)ts.tv_sec * 1000ULL + (uint64_t)(ts.tv_nsec / 1000000);
-}
-
-/* ---- Main ---- */
-
-static int test_passed = 1;
-
-static void check(const char *label, int condition) {
-  if (!condition) {
-    fprintf(stderr, "  FAIL: %s\n", label);
-    test_passed = 0;
-  } else {
+static void check(const char *label, bool condition) {
+  if (condition) {
     printf("  PASS: %s\n", label);
+  } else {
+    fprintf(stderr, "  FAIL: %s\n", label);
+    g_failed = 1;
   }
+}
+
+static void sleep_ms(unsigned int milliseconds) {
+  struct timespec delay;
+  delay.tv_sec = (time_t)(milliseconds / 1000U);
+  delay.tv_nsec = (long)(milliseconds % 1000U) * 1000000L;
+  (void)nanosleep(&delay, NULL);
+}
+
+static void poison_next_pool_allocation(void) {
+  void *memory = NULL;
+  if (posix_memalign(&memory, 64U, sizeof(memdbg_thread_pool_t)) == 0) {
+    memset(memory, 0xA5, sizeof(memdbg_thread_pool_t));
+    free(memory);
+  }
+}
+
+static connection_args_t *make_args(unsigned int id) {
+  connection_args_t *args =
+      (connection_args_t *)malloc(sizeof(connection_args_t));
+  if (args == NULL) return NULL;
+  memset(args, 0, sizeof(*args));
+  args->client_fd = (socket_t)(id + 1U);
+  return args;
+}
+
+static void test_initialized_state(void) {
+  printf("\n--- Initialized pool state ---\n");
+
+  for (unsigned int i = 0U; i < TEST_INIT_ITERATIONS; ++i) {
+    poison_next_pool_allocation();
+    memdbg_thread_pool_t *pool = memdbg_thread_pool_create(2U);
+    if (pool == NULL) {
+      check("pool created after poisoned allocation", false);
+      return;
+    }
+
+    (void)pthread_mutex_lock(&pool->queue_mtx);
+    const bool queue_initialized =
+        pool->queue_head == NULL && pool->queue_tail == NULL &&
+        pool->queue_len == 0U;
+    (void)pthread_mutex_unlock(&pool->queue_mtx);
+
+    if (!queue_initialized) {
+      check("queue fields start empty", false);
+      memdbg_thread_pool_shutdown(pool);
+      memdbg_thread_pool_destroy(pool);
+      return;
+    }
+
+    memdbg_thread_pool_shutdown(pool);
+    memdbg_thread_pool_destroy(pool);
+  }
+
+  check("queue fields start empty", true);
+}
+
+static void test_work_processing(void) {
+  printf("\n--- Work processing ---\n");
+
+  atomic_store_explicit(&g_handled, 0U, memory_order_relaxed);
+  memdbg_thread_pool_t *pool = memdbg_thread_pool_create(TEST_WORKERS);
+  check("pool created", pool != NULL);
+  if (pool == NULL) return;
+
+  check("all requested workers started",
+        memdbg_thread_pool_active_workers(pool) == TEST_WORKERS);
+
+  unsigned int enqueued = 0U;
+  for (unsigned int i = 0U; i < TEST_TASKS; ++i) {
+    connection_args_t *args = make_args(i);
+    if (args == NULL) break;
+    if (memdbg_thread_pool_enqueue(pool, args) != 0) {
+      free(args);
+      break;
+    }
+    ++enqueued;
+  }
+  check("all tasks enqueued", enqueued == TEST_TASKS);
+
+  unsigned int waited_ms = 0U;
+  while (atomic_load_explicit(&g_handled, memory_order_acquire) < enqueued &&
+         waited_ms < TEST_TIMEOUT_MS) {
+    sleep_ms(1U);
+    ++waited_ms;
+  }
+
+  memdbg_thread_pool_shutdown(pool);
+  check("all queued tasks handled",
+        atomic_load_explicit(&g_handled, memory_order_acquire) == enqueued);
+
+  connection_args_t *rejected = make_args(TEST_TASKS);
+  check("post-shutdown test allocation", rejected != NULL);
+  if (rejected != NULL) {
+    check("enqueue rejects work after shutdown",
+          memdbg_thread_pool_enqueue(pool, rejected) == -1);
+    /* A failed enqueue must leave ownership with the caller. */
+    free(rejected);
+  }
+
+  memdbg_thread_pool_destroy(pool);
 }
 
 int main(void) {
-  /* Suppress SIGPIPE so send() on closed socket returns EPIPE. */
-  signal(SIGPIPE, SIG_IGN);
+  printf("=== thread_pool unit tests ===\n");
 
-  printf("\n=== Dynamic Thread Pool Test ===\n\n");
+  test_initialized_state();
+  test_work_processing();
 
-  uint16_t port = 0;
-  int listen_fd = bind_any_port(&port);
-  if (listen_fd < 0) {
-    fprintf(stderr, "FATAL: could not bind listen socket\n");
-    return 1;
-  }
-  g_port = (int)port;
-  printf("Listening on 127.0.0.1:%u  (cap=%d, clients=%d)\n",
-         port, MAX_CONNECTIONS, CLIENT_COUNT);
-
-  /* Start the single acceptor thread. */
-  acceptor_args_t *aargs = (acceptor_args_t *)malloc(sizeof(*aargs));
-  if (aargs == NULL) {
-    fprintf(stderr, "FATAL: malloc acceptor args\n");
-    close(listen_fd);
-    return 1;
-  }
-  aargs->listen_fd = listen_fd;
-
-  pthread_t acceptor_tid;
-  if (pthread_create(&acceptor_tid, NULL, acceptor_thread, aargs) != 0) {
-    fprintf(stderr, "FATAL: could not create acceptor thread\n");
-    free(aargs);
-    close(listen_fd);
-    return 1;
-  }
-
-  /* Allow the listen backlog to settle. */
-  {
-    struct timespec ts = { .tv_sec = 0, .tv_nsec = 50000000L };
-    nanosleep(&ts, NULL);
-  }
-
-  /* Launch all client threads simultaneously. */
-  printf("Launching %d concurrent clients...\n", CLIENT_COUNT);
-
-  pthread_t clients[CLIENT_COUNT];
-  uint64_t t0 = now_ms();
-
-  for (int i = 0; i < CLIENT_COUNT; ++i) {
-    if (pthread_create(&clients[i], NULL, client_thread, NULL) != 0) {
-      fprintf(stderr, "FATAL: could not create client thread %d\n", i);
-      return 1;
-    }
-  }
-
-  /* Join all client threads. */
-  for (int i = 0; i < CLIENT_COUNT; ++i)
-    pthread_join(clients[i], NULL);
-
-  uint64_t dt = now_ms() - t0;
-  printf("Clients finished in %llu ms\n", (unsigned long long)dt);
-
-  /* Signal the acceptor to stop. */
-  atomic_store_explicit(&g_stop_requested, true, memory_order_relaxed);
-  close(listen_fd); /* unblock poll() */
-  pthread_join(acceptor_tid, NULL);
-
-  /* Drain: wait for all handler threads to finish. */
-  printf("Draining %u active handlers...\n",
-         atomic_load_explicit(&g_active_connections, memory_order_relaxed));
-  uint64_t drain_start = now_ms();
-  while (atomic_load_explicit(&g_active_connections, memory_order_relaxed) > 0U) {
-    {
-      struct timespec ts = { .tv_sec = 0, .tv_nsec = 5000000L };
-      nanosleep(&ts, NULL);
-    }
-    if (now_ms() - drain_start > 5000) {
-      fprintf(stderr, "  TIMEOUT waiting for handlers to drain\n");
-      test_passed = 0;
-      break;
-    }
-  }
-
-  int accepted  = atomic_load_explicit(&g_accepted_count, memory_order_relaxed);
-  int rejected  = atomic_load_explicit(&g_rejected_count, memory_order_relaxed);
-  int connected = atomic_load_explicit(&g_connected_count, memory_order_relaxed);
-  uint32_t remaining = atomic_load_explicit(&g_active_connections,
-                                             memory_order_relaxed);
-
-  printf("\n--- Results ---\n");
-  printf("  accepted:   %d\n", accepted);
-  printf("  rejected:   %d\n", rejected);
-  printf("  connected:  %d (clients that got past connect())\n", connected);
-  printf("  active at drain end: %u\n", remaining);
-  printf("  unaccounted: %d (clients that failed connect())\n",
-         CLIENT_COUNT - accepted - rejected);
-
-  printf("\n--- Verdicts ---\n");
-
-  /* 1. The acceptor must not accept more than MAX_CONNECTIONS. */
-  check("accepted <= max_connections", accepted <= MAX_CONNECTIONS);
-
-  /* 2. Total (accepted + rejected) should cover all clients.
-   *    Some clients may fail to connect() if the listen backlog
-   *    is full, so we allow a tiny margin. */
-  int total = accepted + rejected;
-  check("accepted+rejected covers most clients",
-        total >= (int)(CLIENT_COUNT - (CLIENT_COUNT > 4 ? CLIENT_COUNT / 4 : 1)));
-
-  /* 3. At least 2 clients must have been rejected (cap=4, clients=8). */
-  check("at least 2 clients rejected", rejected >= 2);
-
-  /* 4. Accepted count >= 1 (at least one got through). */
-  check("at least 1 accepted", accepted >= 1);
-
-  /* 5. Zero active connections after drain. */
-  check("zero active connections after drain", remaining == 0U);
-
-  /* 6. At least as many clients got past connect() as were accepted.
-   *    On loopback the kernel TCP backlog allows more connect()-level
-   *    handshakes than the application accept(), which is expected. */
-  check("connected >= accepted", connected >= accepted);
-
-  printf("\n=== %s ===\n\n",
-         test_passed ? "ALL PASSED" : "SOME FAILED");
-
-  close(listen_fd);
-  return test_passed ? 0 : 1;
+  printf("\n=== %s ===\n", g_failed == 0 ? "ALL PASSED" : "SOME FAILED");
+  return g_failed;
 }


### PR DESCRIPTION
…aces.

Zero-initialize the cache-aligned pool after posix_memalign, leave enqueue args ownership with the caller on failure, and reject concurrent GoldHEN reinjections without blocking PS4 notifications.

## Summary

- 

## Type of change

- [ ] Payload / protocol
- [ ] Frontend
- [ ] Scanner / debugger / trainer
- [ ] Localization
- [ ] Build / CI / release
- [ ] Documentation
- [x] Bug fix

## Risk surface

- Affected platform(s):
- Affected command(s), screens, or workflows:
- Console safety considerations:

## Verification

- [ ] `make host`
- [ ] `make test`
- [ ] `make check-locales`
- [ ] `make frontend`
- [ ] `make verify`
- [ ] PS5 manual check
- [ ] PS4 manual check
- [ ] Not applicable, because:

## Notes for reviewers

- 

## Scope confirmation

- [x] This change supports legitimate debugging, research, preservation, or offline homebrew development workflows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved daemon startup and shutdown handling to prevent conflicting concurrent entries and ensure reliable cleanup after initialization or listener failures.
  * Corrected thread-pool job ownership handling when enqueueing fails, preventing unexpected release of caller-provided resources.
  * Improved thread-pool initialization reliability.

* **Documentation**
  * Clarified resource ownership and failure behavior for thread-pool job submission.

* **Tests**
  * Added focused coverage for thread-pool initialization, job processing, and shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->