### PR TITLE
Harden and modularize the GDB/IDA bridge

### DIFF
--- a/docs/bridges/ida_gdb_bridge.md
+++ b/docs/bridges/ida_gdb_bridge.md
@@ -63,8 +63,8 @@ standalone asset (`MemDBG-ida-gdb-bridge-{windows,linux,macos}`).
 
 The bridge prints the current process list immediately after connecting to the
 payload, so a PID can be selected without opening the desktop frontend. Incoming
-GDB/IDA commands are logged by default; use `--verbose` when replies and the
-MDBG debugger lifecycle are also needed. It pings the payload every ~10s (idle
+GDB/IDA commands, replies, and the MDBG debugger lifecycle are logged with
+`--verbose`; binary packet bytes are escaped before printing. It pings the payload every ~10s (idle
 timeout is 30s). During detach it stops the target first, restores debugger
 state, and lets `PT_DETACH` resume execution safely.
 
@@ -86,19 +86,21 @@ You can also use stock GDB:
 
 ## Supported RSP subset
 
-- `qSupported`, `QStartNoAckMode`, `qAttached`, `qC`
-- Threads: `qfThreadInfo` / `qsThreadInfo`, `qThreadExtraInfo` (display name), `H`, `T`
-- `qXfer:features:read` → core GPR + SSE (`xmm0`–`xmm15`, `mxcsr`) XML
+- `qSupported`, `QStartNoAckMode`, `QNonStop:0`, `qAttached`, `qC`, `qHostInfo`, `qOffsets`, `qSymbol`
+- Threads: `qfThreadInfo` / `qsThreadInfo`, `qThreadExtraInfo`, `qThreadStopInfo`, `qXfer:threads:read`, `H`, `T`
+- `qXfer:features:read` → the intentionally minimal `i386:x86-64` target description used by IDA
 - `qXfer:memory-map:read` → map from `process_maps` (`ram` entries)
-- `vAttach`, `vCont` (`c`/`s`), `?`, `D`
-- Registers: `g` / `G` / `p` / `P` (GPR + SSE via FXSAVE / `debug_get_fpregs`)
-- Memory: `m` / `M`
+- `qXfer:libraries:read`, `qXfer:exec-file:read`, `qXfer:osdata:read:processes`
+- `qMemoryRegionInfo` and `qSearch:memory`
+- `vAttach`, validated `vCont` (`c`/`C`/`s`/`S`), `vKill`, `?`, `D`, `k`
+- Registers: `g` / `G` / `p` / `P` (GPR, x87 and SSE via FXSAVE / `debug_get_fpregs`)
+- Memory: `m` / `M` / binary `X`, with mapped-range and overflow validation
 - Breakpoints: `Z0`/`z0` (software), `Z1`/`z1` (hardware)
 - Watchpoints: `Z2`–`Z4` / `z2`–`z4`
 - Stop replies via polling `DEBUG_POLL_EVENTS` (all-stop); Ctrl-C → `debug_stop`
 
-Process attach uses bridge `--pid` / `--name` (or IDA `vAttach` in hex). There is
-no RSP OS process-list (`qXfer:osdata`); PS3 / deci3dbg-style modules are out of scope.
+Process attach uses bridge `--pid` / `--name` (or IDA `vAttach` in hex). The OS
+process list and loaded image mappings are also available through RSP XML.
 
 Unsupported packets receive an empty RSP reply (`$#00`).
 
@@ -107,7 +109,8 @@ Unsupported packets receive an empty RSP reply (`$#00`).
 - Single attached PID (same constraint as the MemDBG debugger session).
 - All-stop only (no GDB non-stop mode).
 - No `vRun` / spawn, no on-console `gdbsrv`.
-- X87 (st0–st7 / fctrl…) not in `target.xml` yet (SSE is).
+- The target description stays minimal for IDA compatibility; x87/SSE remain
+  available through individual `p`/`P` packets.
 
 ## Source
 
@@ -115,4 +118,10 @@ Unsupported packets receive an empty RSP reply (`$#00`).
 |---|---|
 | [`tools/gdb_bridge/`](../../tools/gdb_bridge/) | Bridge sources |
 | [`tools/gdb_bridge/gdb_regs.cpp`](../../tools/gdb_bridge/gdb_regs.cpp) | FreeBSD/`memdbg_debug_regs_t` ↔ GDB register order |
-| [`tools/gdb_bridge/rsp_handler.cpp`](../../tools/gdb_bridge/rsp_handler.cpp) | RSP → `Client` debug/memory APIs |
+| [`tools/gdb_bridge/rsp_handler.cpp`](../../tools/gdb_bridge/rsp_handler.cpp) | Session state and packet dispatcher |
+| [`tools/gdb_bridge/rsp_handler_query.cpp`](../../tools/gdb_bridge/rsp_handler_query.cpp) | Queries and XML transfers |
+| [`tools/gdb_bridge/rsp_handler_memory.cpp`](../../tools/gdb_bridge/rsp_handler_memory.cpp) | Memory read/write/search |
+| [`tools/gdb_bridge/rsp_handler_registers.cpp`](../../tools/gdb_bridge/rsp_handler_registers.cpp) | Core, x87 and SSE register packets |
+| [`tools/gdb_bridge/rsp_handler_run.cpp`](../../tools/gdb_bridge/rsp_handler_run.cpp) | Attach, resume, step and breakpoints |
+| [`tools/gdb_bridge/rsp_protocol.cpp`](../../tools/gdb_bridge/rsp_protocol.cpp) | Strict parsing and shared RSP primitives |
+| [`tools/gdb_bridge/rsp_backend.cpp`](../../tools/gdb_bridge/rsp_backend.cpp) | Production `Client` adapter; tests use a deterministic fake backend |

--- a/docs/i18n/ida_gdb_bridge.it.md
+++ b/docs/i18n/ida_gdb_bridge.it.md
@@ -63,8 +63,8 @@ come asset dedicato (`MemDBG-ida-gdb-bridge-{windows,linux,macos}`).
 
 Subito dopo la connessione al payload il bridge stampa l'elenco dei processi,
 permettendo di scegliere il PID senza aprire il frontend desktop. I comandi
-GDB/IDA in ingresso vengono registrati automaticamente; `--verbose` aggiunge le
-risposte e il ciclo di vita del debugger MDBG. Il bridge fa ping al payload ogni
+GDB/IDA, le risposte e il ciclo di vita del debugger MDBG vengono registrati con
+`--verbose`; i byte binari sono sottoposti a escaping prima della stampa. Il bridge fa ping al payload ogni
 ~10s (idle timeout 30s). Durante il detach ferma prima il target, ripristina lo
 stato del debugger e lascia che `PT_DETACH` riprenda l'esecuzione in sicurezza.
 
@@ -86,20 +86,22 @@ Oppure con GDB stock:
 
 ## Subset RSP supportato
 
-- `qSupported`, `QStartNoAckMode`, `qAttached`, `qC`
-- Thread: `qfThreadInfo` / `qsThreadInfo`, `qThreadExtraInfo` (nome), `H`, `T`
-- `qXfer:features:read` → XML core GPR + SSE (`xmm0`–`xmm15`, `mxcsr`)
+- `qSupported`, `QStartNoAckMode`, `QNonStop:0`, `qAttached`, `qC`, `qHostInfo`, `qOffsets`, `qSymbol`
+- Thread: `qfThreadInfo` / `qsThreadInfo`, `qThreadExtraInfo`, `qThreadStopInfo`, `qXfer:threads:read`, `H`, `T`
+- `qXfer:features:read` → descrizione target minimale `i386:x86-64`, mantenuta per compatibilità IDA
 - `qXfer:memory-map:read` → mappa da `process_maps` (tipo `ram`)
-- `vAttach`, `vCont` (`c`/`s`), `?`, `D`
-- Registri: `g` / `G` / `p` / `P` (GPR + SSE via FXSAVE/`debug_get_fpregs`)
-- Memoria: `m` / `M`
+- `qXfer:libraries:read`, `qXfer:exec-file:read`, `qXfer:osdata:read:processes`
+- `qMemoryRegionInfo` e `qSearch:memory`
+- `vAttach`, `vCont` validato (`c`/`C`/`s`/`S`), `vKill`, `?`, `D`, `k`
+- Registri: `g` / `G` / `p` / `P` (GPR, x87 e SSE via FXSAVE/`debug_get_fpregs`)
+- Memoria: `m` / `M` / `X` binario, con validazione mapping e overflow
 - Breakpoint: `Z0`/`z0` (software), `Z1`/`z1` (hardware)
 - Watchpoint: `Z2`–`Z4` / `z2`–`z4`
 - Stop reply via polling `DEBUG_POLL_EVENTS` (all-stop); Ctrl-C → `debug_stop`
 
 L’attach di processo usa `--pid` / `--name` sul bridge (oppure `vAttach` IDA in
-hex). Non c’è process-list OS via RSP (`qXfer:osdata`); PS3 / moduli stile
-deci3dbg sono fuori scope.
+hex). La lista processi e i mapping delle immagini caricate sono disponibili
+anche tramite XML RSP.
 
 I pacchetti non supportati ricevono una risposta RSP vuota (`$#00`).
 
@@ -108,7 +110,8 @@ I pacchetti non supportati ricevono una risposta RSP vuota (`$#00`).
 - Un solo PID attached (stesso vincolo della sessione debugger MemDBG).
 - Solo all-stop (niente non-stop GDB).
 - Niente `vRun` / spawn, niente `gdbsrv` on-console.
-- X87 (st0–st7 / fctrl…) non ancora in `target.xml` (SSE sì).
+- La descrizione target resta minimale per compatibilità IDA; x87/SSE sono
+  comunque disponibili tramite pacchetti individuali `p`/`P`.
 
 ## Sorgenti
 
@@ -116,4 +119,10 @@ I pacchetti non supportati ricevono una risposta RSP vuota (`$#00`).
 |---|---|
 | [`tools/gdb_bridge/`](../../tools/gdb_bridge/) | Sorgenti del bridge |
 | [`tools/gdb_bridge/gdb_regs.cpp`](../../tools/gdb_bridge/gdb_regs.cpp) | Mapping FreeBSD/`memdbg_debug_regs_t` ↔ ordine registri GDB |
-| [`tools/gdb_bridge/rsp_handler.cpp`](../../tools/gdb_bridge/rsp_handler.cpp) | RSP → API debug/memoria del `Client` |
+| [`tools/gdb_bridge/rsp_handler.cpp`](../../tools/gdb_bridge/rsp_handler.cpp) | Stato sessione e dispatcher pacchetti |
+| [`tools/gdb_bridge/rsp_handler_query.cpp`](../../tools/gdb_bridge/rsp_handler_query.cpp) | Query e trasferimenti XML |
+| [`tools/gdb_bridge/rsp_handler_memory.cpp`](../../tools/gdb_bridge/rsp_handler_memory.cpp) | Lettura, scrittura e ricerca memoria |
+| [`tools/gdb_bridge/rsp_handler_registers.cpp`](../../tools/gdb_bridge/rsp_handler_registers.cpp) | Pacchetti registri core, x87 e SSE |
+| [`tools/gdb_bridge/rsp_handler_run.cpp`](../../tools/gdb_bridge/rsp_handler_run.cpp) | Attach, resume, step e breakpoint |
+| [`tools/gdb_bridge/rsp_protocol.cpp`](../../tools/gdb_bridge/rsp_protocol.cpp) | Parsing rigoroso e primitive RSP comuni |
+| [`tools/gdb_bridge/rsp_backend.cpp`](../../tools/gdb_bridge/rsp_backend.cpp) | Adattatore `Client`; i test usano un backend finto deterministico |

--- a/frontend/CMakeLists.txt
+++ b/frontend/CMakeLists.txt
@@ -463,6 +463,12 @@ add_executable(memdbg_gdb_bridge
   ${MEMDBG_GDB_BRIDGE_DIR}/main.cpp
   ${MEMDBG_GDB_BRIDGE_DIR}/rsp_server.cpp
   ${MEMDBG_GDB_BRIDGE_DIR}/rsp_handler.cpp
+  ${MEMDBG_GDB_BRIDGE_DIR}/rsp_handler_query.cpp
+  ${MEMDBG_GDB_BRIDGE_DIR}/rsp_handler_memory.cpp
+  ${MEMDBG_GDB_BRIDGE_DIR}/rsp_handler_registers.cpp
+  ${MEMDBG_GDB_BRIDGE_DIR}/rsp_handler_run.cpp
+  ${MEMDBG_GDB_BRIDGE_DIR}/rsp_backend.cpp
+  ${MEMDBG_GDB_BRIDGE_DIR}/rsp_protocol.cpp
   ${MEMDBG_GDB_BRIDGE_DIR}/gdb_regs.cpp
   src/core/client/memdbg_client.cpp
   src/core/client/client_operations.cpp
@@ -487,6 +493,12 @@ add_executable(memdbg_gdb_bridge_test
   ${MEMDBG_GDB_BRIDGE_DIR}/tests/test_gdb_bridge.cpp
   ${MEMDBG_GDB_BRIDGE_DIR}/gdb_regs.cpp
   ${MEMDBG_GDB_BRIDGE_DIR}/rsp_handler.cpp
+  ${MEMDBG_GDB_BRIDGE_DIR}/rsp_handler_query.cpp
+  ${MEMDBG_GDB_BRIDGE_DIR}/rsp_handler_memory.cpp
+  ${MEMDBG_GDB_BRIDGE_DIR}/rsp_handler_registers.cpp
+  ${MEMDBG_GDB_BRIDGE_DIR}/rsp_handler_run.cpp
+  ${MEMDBG_GDB_BRIDGE_DIR}/rsp_backend.cpp
+  ${MEMDBG_GDB_BRIDGE_DIR}/rsp_protocol.cpp
   ${MEMDBG_GDB_BRIDGE_DIR}/rsp_server.cpp
   src/core/client/memdbg_client.cpp
   src/core/client/client_operations.cpp

--- a/tools/gdb_bridge/CMakeLists.txt
+++ b/tools/gdb_bridge/CMakeLists.txt
@@ -28,6 +28,12 @@ add_executable(memdbg_gdb_bridge
   main.cpp
   rsp_server.cpp
   rsp_handler.cpp
+  rsp_handler_query.cpp
+  rsp_handler_memory.cpp
+  rsp_handler_registers.cpp
+  rsp_handler_run.cpp
+  rsp_backend.cpp
+  rsp_protocol.cpp
   gdb_regs.cpp
   ${FRONTEND_ROOT}/src/core/client/memdbg_client.cpp
   ${FRONTEND_ROOT}/src/core/client/client_operations.cpp
@@ -52,6 +58,12 @@ add_executable(memdbg_gdb_bridge_test
   tests/test_gdb_bridge.cpp
   gdb_regs.cpp
   rsp_handler.cpp
+  rsp_handler_query.cpp
+  rsp_handler_memory.cpp
+  rsp_handler_registers.cpp
+  rsp_handler_run.cpp
+  rsp_backend.cpp
+  rsp_protocol.cpp
   rsp_server.cpp
   ${FRONTEND_ROOT}/src/core/client/memdbg_client.cpp
   ${FRONTEND_ROOT}/src/core/client/client_operations.cpp

--- a/tools/gdb_bridge/gdb_regs.cpp
+++ b/tools/gdb_bridge/gdb_regs.cpp
@@ -24,14 +24,11 @@ int hex_value(char c) {
   return -1;
 }
 
-bool fxsave_ready(const memdbg_debug_fpregs_t &fpregs) {
-  return fpregs.length >= kFxsaveMinLen;
-}
+bool fxsave_ready(const memdbg_debug_fpregs_t &fpregs) { return fpregs.length >= kFxsaveMinLen; }
 
 void ensure_fxsave(memdbg_debug_fpregs_t &fpregs) {
   if (fpregs.length < kFxsaveMinLen) {
-    std::memset(fpregs.data + fpregs.length, 0,
-                kFxsaveMinLen - fpregs.length);
+    std::memset(fpregs.data + fpregs.length, 0, kFxsaveMinLen - fpregs.length);
     fpregs.length = static_cast<uint32_t>(kFxsaveMinLen);
   }
 }
@@ -39,24 +36,16 @@ void ensure_fxsave(memdbg_debug_fpregs_t &fpregs) {
 } // namespace
 
 size_t gdb_reg_size(int regno) {
-  if (gdb_reg_is_core(regno)) {
-    return regno <= GDB_RIP ? 8U : 4U;
-  }
-  if (gdb_reg_is_x87(regno)) {
-    return regno <= GDB_ST7 ? 10U : 4U;
-  }
+  if (gdb_reg_is_core(regno)) { return regno <= GDB_RIP ? 8U : 4U; }
+  if (gdb_reg_is_x87(regno)) { return regno <= GDB_ST7 ? 10U : 4U; }
   if (regno >= GDB_XMM0 && regno <= GDB_XMM15) return kFxsaveXmmBytes;
   if (regno == GDB_MXCSR) return 4U;
   return 0U;
 }
 
-bool gdb_reg_is_core(int regno) {
-  return regno >= 0 && regno < GDB_CORE_COUNT;
-}
+bool gdb_reg_is_core(int regno) { return regno >= 0 && regno < GDB_CORE_COUNT; }
 
-bool gdb_reg_is_x87(int regno) {
-  return regno >= GDB_ST0 && regno <= GDB_FOP;
-}
+bool gdb_reg_is_x87(int regno) { return regno >= GDB_ST0 && regno <= GDB_FOP; }
 
 bool gdb_reg_is_sse(int regno) {
   return (regno >= GDB_XMM0 && regno <= GDB_XMM15) || regno == GDB_MXCSR;
@@ -176,8 +165,8 @@ bool gdb_set_reg_value(memdbg_debug_regs_t &regs, int regno, uint64_t value) {
   }
 }
 
-bool gdb_get_sse_bytes(const memdbg_debug_fpregs_t &fpregs, int regno,
-                       uint8_t *out, size_t out_size) {
+bool gdb_get_sse_bytes(const memdbg_debug_fpregs_t &fpregs, int regno, uint8_t *out,
+                       size_t out_size) {
   if (!out || !gdb_reg_is_sse(regno)) return false;
   const size_t need = gdb_reg_size(regno);
   if (out_size < need) return false;
@@ -187,15 +176,12 @@ bool gdb_get_sse_bytes(const memdbg_debug_fpregs_t &fpregs, int regno,
     std::memcpy(out, fpregs.data + kFxsaveMxcsrOff, 4U);
     return true;
   }
-  const size_t off =
-      kFxsaveXmm0Off +
-      static_cast<size_t>(regno - GDB_XMM0) * kFxsaveXmmBytes;
+  const size_t off = kFxsaveXmm0Off + static_cast<size_t>(regno - GDB_XMM0) * kFxsaveXmmBytes;
   std::memcpy(out, fpregs.data + off, kFxsaveXmmBytes);
   return true;
 }
 
-bool gdb_set_sse_bytes(memdbg_debug_fpregs_t &fpregs, int regno,
-                       const uint8_t *data, size_t size) {
+bool gdb_set_sse_bytes(memdbg_debug_fpregs_t &fpregs, int regno, const uint8_t *data, size_t size) {
   if (!data || !gdb_reg_is_sse(regno)) return false;
   if (size != gdb_reg_size(regno)) return false;
   ensure_fxsave(fpregs);
@@ -203,11 +189,60 @@ bool gdb_set_sse_bytes(memdbg_debug_fpregs_t &fpregs, int regno,
     std::memcpy(fpregs.data + kFxsaveMxcsrOff, data, 4U);
     return true;
   }
-  const size_t off =
-      kFxsaveXmm0Off +
-      static_cast<size_t>(regno - GDB_XMM0) * kFxsaveXmmBytes;
+  const size_t off = kFxsaveXmm0Off + static_cast<size_t>(regno - GDB_XMM0) * kFxsaveXmmBytes;
   std::memcpy(fpregs.data + off, data, kFxsaveXmmBytes);
   return true;
+}
+
+bool gdb_get_x87_bytes(const memdbg_debug_fpregs_t &fpregs, int regno, uint8_t *out,
+                       size_t out_size) {
+  if (!out || !gdb_reg_is_x87(regno)) return false;
+  const size_t need = gdb_reg_size(regno);
+  if (out_size < need) return false;
+  std::memset(out, 0, need);
+  if (!fxsave_ready(fpregs)) return true;
+
+  if (regno >= GDB_ST0 && regno <= GDB_ST7) {
+    const size_t offset = kFxsaveSt0Off + static_cast<size_t>(regno - GDB_ST0) * kFxsaveStStride;
+    std::memcpy(out, fpregs.data + offset, 10U);
+    return true;
+  }
+
+  uint32_t value = 0U;
+  switch (regno) {
+  case GDB_FCTRL: std::memcpy(&value, fpregs.data + 0U, 2U); break;
+  case GDB_FSTAT: std::memcpy(&value, fpregs.data + 2U, 2U); break;
+  case GDB_FTAG: std::memcpy(&value, fpregs.data + 4U, 1U); break;
+  case GDB_FISEG: value = 0U; break;
+  case GDB_FIOFF: std::memcpy(&value, fpregs.data + 8U, 4U); break;
+  case GDB_FOSEG: value = 0U; break;
+  case GDB_FOOFF: std::memcpy(&value, fpregs.data + 16U, 4U); break;
+  case GDB_FOP: std::memcpy(&value, fpregs.data + 6U, 2U); break;
+  default: return false;
+  }
+  std::memcpy(out, &value, 4U);
+  return true;
+}
+
+bool gdb_set_x87_bytes(memdbg_debug_fpregs_t &fpregs, int regno, const uint8_t *data, size_t size) {
+  if (!data || !gdb_reg_is_x87(regno) || size != gdb_reg_size(regno)) return false;
+  ensure_fxsave(fpregs);
+  if (regno >= GDB_ST0 && regno <= GDB_ST7) {
+    const size_t offset = kFxsaveSt0Off + static_cast<size_t>(regno - GDB_ST0) * kFxsaveStStride;
+    std::memcpy(fpregs.data + offset, data, 10U);
+    return true;
+  }
+  switch (regno) {
+  case GDB_FCTRL: std::memcpy(fpregs.data + 0U, data, 2U); return true;
+  case GDB_FSTAT: std::memcpy(fpregs.data + 2U, data, 2U); return true;
+  case GDB_FTAG: std::memcpy(fpregs.data + 4U, data, 1U); return true;
+  case GDB_FISEG: return true; /* not represented by 64-bit FXSAVE */
+  case GDB_FIOFF: std::memcpy(fpregs.data + 8U, data, 4U); return true;
+  case GDB_FOSEG: return true; /* not represented by 64-bit FXSAVE */
+  case GDB_FOOFF: std::memcpy(fpregs.data + 16U, data, 4U); return true;
+  case GDB_FOP: std::memcpy(fpregs.data + 6U, data, 2U); return true;
+  default: return false;
+  }
 }
 
 /*
@@ -243,8 +278,13 @@ bool gdb_decode_g_core(const std::string &hex, memdbg_debug_regs_t &regs) {
 std::string gdb_encode_g_packet(const memdbg_debug_regs_t &regs,
                                 const memdbg_debug_fpregs_t *fpregs) {
   std::string out = gdb_encode_g_core(regs);
-  /* Insert x87 112-byte zero padding (224 hex zeros) for standard amd64 layout. */
-  out.append(kX87PaddingBytes * 2U, '0');
+  uint8_t x87[10]{};
+  for (int regno = GDB_ST0; regno <= GDB_FOP; ++regno) {
+    const size_t size = gdb_reg_size(regno);
+    std::memset(x87, 0, sizeof(x87));
+    if (fpregs) (void)gdb_get_x87_bytes(*fpregs, regno, x87, sizeof(x87));
+    out += bytes_to_hex(x87, size);
+  }
 
   /* Document order in target.xml: xmm0..xmm15 then mxcsr. */
   uint8_t tmp[16]{};
@@ -257,9 +297,7 @@ std::string gdb_encode_g_packet(const memdbg_debug_regs_t &regs,
     out += bytes_to_hex(tmp, kFxsaveXmmBytes);
   }
   uint8_t mxcsr[4]{};
-  if (fpregs) {
-    (void)gdb_get_sse_bytes(*fpregs, GDB_MXCSR, mxcsr, sizeof(mxcsr));
-  }
+  if (fpregs) { (void)gdb_get_sse_bytes(*fpregs, GDB_MXCSR, mxcsr, sizeof(mxcsr)); }
   out += bytes_to_hex(mxcsr, sizeof(mxcsr));
   return out;
 }
@@ -267,18 +305,23 @@ std::string gdb_encode_g_packet(const memdbg_debug_regs_t &regs,
 bool gdb_decode_g_packet(const std::string &hex, memdbg_debug_regs_t &regs,
                          memdbg_debug_fpregs_t *fpregs) {
   if (!gdb_decode_g_core(hex, regs)) return false;
-  /* Core hex length: 328 chars. x87 padding: 224 chars. Total prefix: 552 chars. */
-  size_t offset = 552U;
-  if (hex.size() < offset) return false;
-  if (!fpregs) {
-    return true;
-  }
+  size_t offset = 328U;
+  if (!fpregs) { return hex.size() >= offset + kX87PaddingBytes * 2U; }
   ensure_fxsave(*fpregs);
+  uint8_t x87[10]{};
+  for (int regno = GDB_ST0; regno <= GDB_FOP; ++regno) {
+    const size_t size = gdb_reg_size(regno);
+    if (offset + size * 2U > hex.size() ||
+        !hex_to_bytes(hex.substr(offset, size * 2U), x87, size) ||
+        !gdb_set_x87_bytes(*fpregs, regno, x87, size)) {
+      return false;
+    }
+    offset += size * 2U;
+  }
   uint8_t tmp[16]{};
   for (int regno = GDB_XMM0; regno <= GDB_XMM15; ++regno) {
     if (offset + kFxsaveXmmBytes * 2U > hex.size()) return false;
-    if (!hex_to_bytes(hex.substr(offset, kFxsaveXmmBytes * 2U), tmp,
-                      kFxsaveXmmBytes)) {
+    if (!hex_to_bytes(hex.substr(offset, kFxsaveXmmBytes * 2U), tmp, kFxsaveXmmBytes)) {
       return false;
     }
     if (!gdb_set_sse_bytes(*fpregs, regno, tmp, kFxsaveXmmBytes)) return false;

--- a/tools/gdb_bridge/gdb_regs.hpp
+++ b/tools/gdb_bridge/gdb_regs.hpp
@@ -88,6 +88,8 @@ enum GdbReg : int {
 };
 
 constexpr size_t kFxsaveMinLen = 512U;
+constexpr size_t kFxsaveSt0Off = 32U;
+constexpr size_t kFxsaveStStride = 16U;
 constexpr size_t kFxsaveMxcsrOff = 24U;
 constexpr size_t kFxsaveXmm0Off = 160U;
 constexpr size_t kFxsaveXmmBytes = 16U;
@@ -118,17 +120,19 @@ bool gdb_set_reg_value(memdbg_debug_regs_t &regs, int regno, uint64_t value);
 std::string gdb_encode_g_core(const memdbg_debug_regs_t &regs);
 bool gdb_decode_g_core(const std::string &hex, memdbg_debug_regs_t &regs);
 
-/* Full g/G matching target.xml (core + SSE). Missing/short fpregs → zero SSE. */
+/* Standard amd64 g/G packet (core + x87 + SSE). */
 std::string gdb_encode_g_packet(const memdbg_debug_regs_t &regs,
                                 const memdbg_debug_fpregs_t *fpregs);
 bool gdb_decode_g_packet(const std::string &hex, memdbg_debug_regs_t &regs,
                          memdbg_debug_fpregs_t *fpregs);
 
-/* Read/write one SSE register into an FXSAVE-backed fpregs blob. */
-bool gdb_get_sse_bytes(const memdbg_debug_fpregs_t &fpregs, int regno,
-                       uint8_t *out, size_t out_size);
-bool gdb_set_sse_bytes(memdbg_debug_fpregs_t &fpregs, int regno,
-                       const uint8_t *data, size_t size);
+/* Read/write one x87/SSE register in an FXSAVE-backed fpregs blob. */
+bool gdb_get_sse_bytes(const memdbg_debug_fpregs_t &fpregs, int regno, uint8_t *out,
+                       size_t out_size);
+bool gdb_set_sse_bytes(memdbg_debug_fpregs_t &fpregs, int regno, const uint8_t *data, size_t size);
+bool gdb_get_x87_bytes(const memdbg_debug_fpregs_t &fpregs, int regno, uint8_t *out,
+                       size_t out_size);
+bool gdb_set_x87_bytes(memdbg_debug_fpregs_t &fpregs, int regno, const uint8_t *data, size_t size);
 
 } // namespace memdbg::gdb_bridge
 

--- a/tools/gdb_bridge/rsp_backend.cpp
+++ b/tools/gdb_bridge/rsp_backend.cpp
@@ -1,0 +1,90 @@
+/*
+ * MemDBG - Production Client adapter for the GDB RSP backend.
+ * Copyright (C) 2026 SeregonWar
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "rsp_backend.hpp"
+
+#include <memory>
+
+namespace memdbg::gdb_bridge {
+namespace {
+
+class ClientRspBackend final : public RspBackend {
+public:
+  explicit ClientRspBackend(memdbg::frontend::Client &client) : client_(client) {}
+
+  std::string last_error() const override { return client_.last_error(); }
+  bool process_list(std::vector<memdbg::frontend::ProcessEntry> &out) override {
+    return client_.process_list(out);
+  }
+  bool process_maps(int32_t pid, std::vector<memdbg::frontend::MapEntry> &out) override {
+    return client_.process_maps(pid, out);
+  }
+  bool process_info(int32_t pid, memdbg::frontend::ProcessInfo &out) override {
+    return client_.process_info(pid, out);
+  }
+  bool process_kill(int32_t pid) override { return client_.process_kill(pid); }
+  bool memory_read(int32_t pid, uint64_t address, uint32_t length,
+                   std::vector<uint8_t> &out) override {
+    return client_.memory_read(pid, address, length, out);
+  }
+  bool memory_write(int32_t pid, uint64_t address, const std::vector<uint8_t> &data,
+                    uint32_t &written) override {
+    return client_.memory_write(pid, address, data, written);
+  }
+  bool debug_attach(int32_t pid) override { return client_.debug_attach(pid); }
+  bool debug_detach() override { return client_.debug_detach(); }
+  bool debug_stop() override { return client_.debug_stop(); }
+  bool debug_continue() override { return client_.debug_continue(); }
+  bool debug_step(int32_t lwp) override { return client_.debug_step(lwp); }
+  bool debug_get_threads(std::vector<memdbg::frontend::Client::DebugThreadEntry> &out) override {
+    return client_.debug_get_threads(out);
+  }
+  bool debug_get_regs(int32_t lwp, memdbg::frontend::Client::DebugRegs &out) override {
+    return client_.debug_get_regs(lwp, out);
+  }
+  bool debug_set_regs(int32_t lwp, const memdbg::frontend::Client::DebugRegs &in) override {
+    return client_.debug_set_regs(lwp, in);
+  }
+  bool debug_get_dbregs(int32_t lwp, memdbg::frontend::Client::DebugDbregs &out) override {
+    return client_.debug_get_dbregs(lwp, out);
+  }
+  bool debug_get_fpregs(int32_t lwp, memdbg::frontend::Client::DebugFpregs &out) override {
+    return client_.debug_get_fpregs(lwp, out);
+  }
+  bool debug_set_fpregs(int32_t lwp, const memdbg::frontend::Client::DebugFpregs &in) override {
+    return client_.debug_set_fpregs(lwp, in);
+  }
+  bool debug_set_breakpoint(uint64_t address, uint32_t kind) override {
+    return client_.debug_set_breakpoint(address, kind);
+  }
+  bool debug_clear_breakpoint(uint64_t address) override {
+    return client_.debug_clear_breakpoint(address);
+  }
+  bool debug_set_watchpoint(uint64_t address, uint32_t length, uint32_t type) override {
+    return client_.debug_set_watchpoint(address, length, type);
+  }
+  bool debug_clear_watchpoint(uint64_t address) override {
+    return client_.debug_clear_watchpoint(address);
+  }
+  bool
+  debug_get_watchpoints(std::vector<memdbg::frontend::Client::DebugWatchpointEntry> &out) override {
+    return client_.debug_get_watchpoints(out);
+  }
+  bool debug_poll_events(bool &stopped, int32_t &stop_lwp) override {
+    return client_.debug_poll_events(stopped, stop_lwp);
+  }
+
+private:
+  memdbg::frontend::Client &client_;
+};
+
+} // namespace
+
+std::unique_ptr<RspBackend> make_client_rsp_backend(memdbg::frontend::Client &client) {
+  return std::make_unique<ClientRspBackend>(client);
+}
+
+} // namespace memdbg::gdb_bridge

--- a/tools/gdb_bridge/rsp_backend.hpp
+++ b/tools/gdb_bridge/rsp_backend.hpp
@@ -1,0 +1,57 @@
+/*
+ * MemDBG - Testable backend boundary for the GDB RSP bridge.
+ * Copyright (C) 2026 SeregonWar
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef MEMDBG_GDB_BRIDGE_RSP_BACKEND_HPP
+#define MEMDBG_GDB_BRIDGE_RSP_BACKEND_HPP
+
+#include "memdbg_client.hpp"
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace memdbg::gdb_bridge {
+
+class RspBackend {
+public:
+  virtual ~RspBackend() = default;
+
+  virtual std::string last_error() const = 0;
+  virtual bool process_list(std::vector<memdbg::frontend::ProcessEntry> &out) = 0;
+  virtual bool process_maps(int32_t pid, std::vector<memdbg::frontend::MapEntry> &out) = 0;
+  virtual bool process_info(int32_t pid, memdbg::frontend::ProcessInfo &out) = 0;
+  virtual bool process_kill(int32_t pid) = 0;
+  virtual bool memory_read(int32_t pid, uint64_t address, uint32_t length,
+                           std::vector<uint8_t> &out) = 0;
+  virtual bool memory_write(int32_t pid, uint64_t address, const std::vector<uint8_t> &data,
+                            uint32_t &written) = 0;
+
+  virtual bool debug_attach(int32_t pid) = 0;
+  virtual bool debug_detach() = 0;
+  virtual bool debug_stop() = 0;
+  virtual bool debug_continue() = 0;
+  virtual bool debug_step(int32_t lwp) = 0;
+  virtual bool debug_get_threads(std::vector<memdbg::frontend::Client::DebugThreadEntry> &out) = 0;
+  virtual bool debug_get_regs(int32_t lwp, memdbg::frontend::Client::DebugRegs &out) = 0;
+  virtual bool debug_set_regs(int32_t lwp, const memdbg::frontend::Client::DebugRegs &in) = 0;
+  virtual bool debug_get_dbregs(int32_t lwp, memdbg::frontend::Client::DebugDbregs &out) = 0;
+  virtual bool debug_get_fpregs(int32_t lwp, memdbg::frontend::Client::DebugFpregs &out) = 0;
+  virtual bool debug_set_fpregs(int32_t lwp, const memdbg::frontend::Client::DebugFpregs &in) = 0;
+  virtual bool debug_set_breakpoint(uint64_t address, uint32_t kind) = 0;
+  virtual bool debug_clear_breakpoint(uint64_t address) = 0;
+  virtual bool debug_set_watchpoint(uint64_t address, uint32_t length, uint32_t type) = 0;
+  virtual bool debug_clear_watchpoint(uint64_t address) = 0;
+  virtual bool
+  debug_get_watchpoints(std::vector<memdbg::frontend::Client::DebugWatchpointEntry> &out) = 0;
+  virtual bool debug_poll_events(bool &stopped, int32_t &stop_lwp) = 0;
+};
+
+std::unique_ptr<RspBackend> make_client_rsp_backend(memdbg::frontend::Client &client);
+
+} // namespace memdbg::gdb_bridge
+
+#endif /* MEMDBG_GDB_BRIDGE_RSP_BACKEND_HPP */

--- a/tools/gdb_bridge/rsp_handler.cpp
+++ b/tools/gdb_bridge/rsp_handler.cpp
@@ -1,129 +1,21 @@
-/*
- * MemDBG - RSP command dispatch onto MDBG Client.
- * Copyright (C) 2026 SeregonWar
- * SPDX-License-Identifier: GPL-3.0-or-later
- */
-
 #include "rsp_handler.hpp"
 
 #include "gdb_regs.hpp"
-#include "target_xml.h"
 
-#include <cctype>
-#include <chrono>
 #include <cstdarg>
 #include <cstdio>
-#include <cstdlib>
 #include <cstring>
-#include <thread>
-
+#include <utility>
 namespace memdbg::gdb_bridge {
 
-namespace {
+using namespace detail;
 
-constexpr uint32_t kMemChunk = 0x10000U; /* 64 KiB per MEMORY_READ */
+RspHandler::RspHandler(memdbg::frontend::Client &client, int32_t initial_pid, bool verbose)
+  : owned_backend_(make_client_rsp_backend(client)), backend_(*owned_backend_), pid_(initial_pid),
+    verbose_(verbose) {}
 
-
-/*
- * +-------------------------------------------------------------------+
- * | Helper Functions                                                  |
- * +-------------------------------------------------------------------+
- */
-bool parse_hex_u64(const std::string &s, size_t begin, size_t end,
-                   uint64_t &out) {
-  if (begin >= end) return false;
-  uint64_t value = 0U;
-  for (size_t i = begin; i < end; ++i) {
-    const char c = s[i];
-    int n = -1;
-    if (c >= '0' && c <= '9') n = c - '0';
-    else if (c >= 'a' && c <= 'f') n = c - 'a' + 10;
-    else if (c >= 'A' && c <= 'F') n = c - 'A' + 10;
-    else return false;
-    value = (value << 4U) | static_cast<uint64_t>(n);
-  }
-  out = value;
-  return true;
-}
-
-bool parse_hex_u64(const char *s, uint64_t &out) {
-  if (s == nullptr || *s == '\0') return false;
-  char *end = nullptr;
-  out = std::strtoull(s, &end, 16);
-  return end != s;
-}
-
-std::string err_packet(int code) {
-  char buf[8];
-  std::snprintf(buf, sizeof(buf), "E%02x", code & 0xFF);
-  return std::string(buf);
-}
-
-int watch_type_from_z(char kind) {
-  /* MemDBG: 0=exec, 1=write, 2=read, 3=rw */
-  switch (kind) {
-  case '1': return 0; /* hardware exec -> exec watch / HW BP uses set_breakpoint */
-  case '2': return 1;
-  case '3': return 2;
-  case '4': return 3;
-  default: return -1;
-  }
-}
-
-} // namespace
-
-bool parse_thread_id(const char *s, int32_t &pid_out, int32_t &tid_out) {
-  if (s == nullptr || *s == '\0') return false;
-  if (*s == 'p') s++;
-  char *end = nullptr;
-  if (std::strncmp(s, "-1", 2) == 0) {
-    tid_out = -1;
-    s += 2;
-  } else {
-    uint64_t val = std::strtoull(s, &end, 16);
-    if (end == s) return false;
-    tid_out = static_cast<int32_t>(val);
-    s = end;
-  }
-  if (*s == '.') {
-    s++;
-    pid_out = tid_out;
-    if (std::strncmp(s, "-1", 2) == 0) {
-      tid_out = -1;
-    } else {
-      uint64_t val2 = std::strtoull(s, &end, 16);
-      if (end != s) tid_out = static_cast<int32_t>(val2);
-    }
-  } else {
-    pid_out = 0;
-  }
-  return true;
-}
-
-std::string gdb_watchpoint_stop_field(
-    uint64_t dr6,
-    const std::vector<memdbg::frontend::Client::DebugWatchpointEntry> &entries) {
-  const uint64_t hits = dr6 & 0xFULL;
-  for (const auto &entry : entries) {
-    if (!entry.installed || entry.slot >= 4U ||
-        (hits & (1ULL << entry.slot)) == 0U) {
-      continue;
-    }
-    if (entry.type == 0U) return "hwbreak:;";
-    const char *reason = entry.type == 1U ? "watch"
-                         : entry.type == 2U ? "rwatch"
-                                            : "awatch";
-    char buf[64];
-    std::snprintf(buf, sizeof(buf), "%s:%llx;", reason,
-                  static_cast<unsigned long long>(entry.address));
-    return std::string(buf);
-  }
-  return std::string();
-}
-
-RspHandler::RspHandler(memdbg::frontend::Client &client, int32_t initial_pid,
-                       bool verbose)
-    : client_(client), pid_(initial_pid), verbose_(verbose) {}
+RspHandler::RspHandler(RspBackend &backend, int32_t initial_pid, bool verbose)
+  : backend_(backend), pid_(initial_pid), verbose_(verbose) {}
 
 void RspHandler::logf(const char *fmt, ...) const {
   if (!verbose_ || fmt == nullptr) return;
@@ -136,35 +28,44 @@ void RspHandler::logf(const char *fmt, ...) const {
 }
 
 void RspHandler::log_rsp_command(const std::string &packet) const {
-  /* Keep the exact IDA/GDB command sequence in every field report. */
-  if (packet.size() > 96U && !packet.empty() &&
-      (packet[0] == 'M' || packet[0] == 'X' || packet[0] == 'G')) {
-    std::fprintf(stderr, "[gdb_bridge] rsp <- %.64s... (%zu bytes)\n",
-                 packet.c_str(), packet.size());
-  } else {
-    std::fprintf(stderr, "[gdb_bridge] rsp <- %s\n", packet.c_str());
+  if (!verbose_) return;
+  const size_t limit = packet.size() < 96U ? packet.size() : 96U;
+  std::string display;
+  display.reserve(limit);
+  for (size_t i = 0; i < limit; ++i) {
+    const unsigned char c = static_cast<unsigned char>(packet[i]);
+    if (c >= 0x20U && c <= 0x7EU) {
+      display.push_back(static_cast<char>(c));
+    } else {
+      char escaped[5];
+      std::snprintf(escaped, sizeof(escaped), "\\x%02x", c);
+      display += escaped;
+    }
   }
+  logf("rsp <- %s%s (%zu bytes)", display.c_str(), packet.size() > limit ? "..." : "",
+       packet.size());
 }
 
 bool RspHandler::safe_detach() {
   if (!attached_) return true;
   /* Stop before the payload restores software breakpoints.  PT_DETACH resumes
    * the process; continuing first races live code against INT3 removal. */
-  if (!client_.debug_stop()) {
-    logf("pre-detach stop failed: %s", client_.last_error().c_str());
-  }
-  if (!client_.debug_detach()) {
-    logf("debug_detach failed: %s", client_.last_error().c_str());
+  if (!backend_.debug_stop()) { logf("pre-detach stop failed: %s", backend_.last_error().c_str()); }
+  if (!backend_.debug_detach()) {
+    logf("debug_detach failed: %s", backend_.last_error().c_str());
     return false;
   } else {
     logf("detached pid=%d", static_cast<int>(pid_));
   }
   attached_ = false;
   stop_lwp_ = 0;
+  stop_signal_ = 5U;
   stop_reason_.clear();
   general_thread_ = 0;
   continue_thread_ = 0;
   threads_.clear();
+  memory_maps_.clear();
+  memory_maps_known_ = false;
   return true;
 }
 
@@ -177,8 +78,8 @@ bool RspHandler::ensure_attached() {
     return false;
   }
   logf("debug_attach pid=%d", static_cast<int>(pid_));
-  if (!client_.debug_attach(pid_)) {
-    logf("debug_attach failed: %s", client_.last_error().c_str());
+  if (!backend_.debug_attach(pid_)) {
+    logf("debug_attach failed: %s", backend_.last_error().c_str());
     return false;
   }
   attached_ = true;
@@ -187,13 +88,27 @@ bool RspHandler::ensure_attached() {
     stop_lwp_ = threads_[0].lwp;
     general_thread_ = stop_lwp_;
   }
+  (void)refresh_memory_maps();
   return true;
 }
 
 void RspHandler::refresh_threads() {
   threads_.clear();
   if (!attached_) return;
-  (void)client_.debug_get_threads(threads_);
+  (void)backend_.debug_get_threads(threads_);
+}
+
+bool RspHandler::refresh_memory_maps() {
+  std::vector<memdbg::frontend::MapEntry> maps;
+  if (!backend_.process_maps(pid_, maps)) {
+    memory_maps_.clear();
+    memory_maps_known_ = false;
+    logf("process map refresh failed: %s", backend_.last_error().c_str());
+    return false;
+  }
+  memory_maps_ = std::move(maps);
+  memory_maps_known_ = true;
+  return true;
 }
 
 int32_t RspHandler::current_thread() const {
@@ -205,12 +120,13 @@ int32_t RspHandler::current_thread() const {
 
 std::string RspHandler::stop_reply() const {
   const int32_t tid = stop_lwp_ > 0 ? stop_lwp_ : current_thread();
-  std::string reply = "T05";
+  char signal[4];
+  std::snprintf(signal, sizeof(signal), "T%02x", stop_signal_);
+  std::string reply(signal);
   reply += stop_reason_;
   if (tid > 0) {
     char buf[32];
-    std::snprintf(buf, sizeof(buf), "thread:%x;",
-                  static_cast<unsigned>(tid));
+    std::snprintf(buf, sizeof(buf), "thread:%x;", static_cast<unsigned>(tid));
     reply += buf;
   }
   return reply;
@@ -221,364 +137,10 @@ void RspHandler::capture_stop_reason(int32_t lwp) {
   if (lwp <= 0) return;
   memdbg::frontend::Client::DebugDbregs dbregs;
   std::vector<memdbg::frontend::Client::DebugWatchpointEntry> entries;
-  if (!client_.debug_get_dbregs(lwp, dbregs) ||
-      !client_.debug_get_watchpoints(entries)) {
+  if (!backend_.debug_get_dbregs(lwp, dbregs) || !backend_.debug_get_watchpoints(entries)) {
     return;
   }
   stop_reason_ = gdb_watchpoint_stop_field(dbregs.dbregs.dr[6], entries);
-}
-
-std::string RspHandler::qxfer_features(const std::string &annex, size_t offset,
-                                       size_t length) const {
-  if (annex != "target.xml") return err_packet(1);
-  const std::string xml(kMemdbgGdbTargetXml);
-  if (offset >= xml.size()) return "l";
-  const size_t avail = xml.size() - offset;
-  const size_t n = length < avail ? length : avail;
-  const bool last = offset + n >= xml.size();
-  std::string out;
-  out.push_back(last ? 'l' : 'm');
-  out.append(xml, offset, n);
-  return out;
-}
-
-std::string RspHandler::qxfer_memory_map(size_t offset, size_t length) {
-  if (!ensure_attached()) return err_packet(1);
-  std::vector<memdbg::frontend::MapEntry> maps;
-  if (!client_.process_maps(pid_, maps)) return err_packet(1);
-
-  std::string xml = "<?xml version=\"1.0\"?>"
-                    "<!DOCTYPE memory-map PUBLIC "
-                    "\"+//IDN gnu.org/DTD GDB Memory Map V1.0//EN\" "
-                    "\"http://sourceware.org/gdb/gdb-memory-map.dtd\">"
-                    "<memory-map>";
-  for (const auto &m : maps) {
-    if (m.end <= m.start) continue;
-    const uint64_t len = m.end - m.start;
-    char buf[128];
-    std::snprintf(buf, sizeof(buf),
-                  "<memory type=\"ram\" start=\"0x%llx\" length=\"0x%llx\"/>",
-                  static_cast<unsigned long long>(m.start),
-                  static_cast<unsigned long long>(len));
-    xml += buf;
-  }
-  xml += "</memory-map>";
-
-  if (offset >= xml.size()) return "l";
-  const size_t avail = xml.size() - offset;
-  const size_t n = length < avail ? length : avail;
-  const bool last = offset + n >= xml.size();
-  std::string out;
-  out.push_back(last ? 'l' : 'm');
-  out.append(xml, offset, n);
-  return out;
-}
-
-std::string RspHandler::handle_continue_or_step(bool step, RspConnection &conn,
-                                                 int32_t lwp) {
-  if (!ensure_attached()) return err_packet(1);
-
-  bool ok = false;
-  if (step) {
-    const int32_t tid = lwp != 0 ? lwp : current_thread();
-    logf("debug_step lwp=%d", static_cast<int>(tid));
-    ok = client_.debug_step(tid);
-  } else {
-    logf("debug_continue");
-    ok = client_.debug_continue();
-  }
-  if (!ok) {
-    logf("%s failed: %s", step ? "debug_step" : "debug_continue",
-         client_.last_error().c_str());
-    return err_packet(1);
-  }
-  stop_reason_.clear();
-
-  for (;;) {
-    if (conn.poll_interrupt(50U)) {
-      (void)client_.debug_stop();
-      bool stopped = false;
-      int32_t stop_lwp = 0;
-      (void)client_.debug_poll_events(stopped, stop_lwp);
-      if (stop_lwp != 0) stop_lwp_ = stop_lwp;
-      return "T02"; /* SIGINT */
-    }
-
-    bool stopped = false;
-    int32_t stop_lwp = 0;
-    if (!client_.debug_poll_events(stopped, stop_lwp)) {
-      return err_packet(1);
-    }
-    if (stopped) {
-      if (stop_lwp != 0) stop_lwp_ = stop_lwp;
-      capture_stop_reason(stop_lwp_);
-      general_thread_ = stop_lwp_;
-      return stop_reply();
-    }
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
-  }
-}
-
-std::string RspHandler::handle_memory_read(const std::string &packet) {
-  /* maddr,length */
-  if (!ensure_attached()) return err_packet(1);
-  const size_t comma = packet.find(',');
-  if (comma == std::string::npos) return err_packet(1);
-  uint64_t addr = 0U;
-  uint64_t length = 0U;
-  if (!parse_hex_u64(packet, 1U, comma, addr)) return err_packet(1);
-  if (!parse_hex_u64(packet, comma + 1U, packet.size(), length))
-    return err_packet(1);
-  if (length == 0U) return std::string();
-  if (length > 0x100000U) length = 0x100000U;
-
-  std::string hex;
-  hex.reserve(static_cast<size_t>(length) * 2U);
-  uint64_t done = 0U;
-  while (done < length) {
-    uint32_t chunk = static_cast<uint32_t>(length - done);
-    if (chunk > kMemChunk) chunk = kMemChunk;
-    std::vector<uint8_t> data;
-    if (!client_.memory_read(pid_, addr + done, chunk, data) ||
-        data.size() != chunk) {
-      return err_packet(1);
-    }
-    hex += bytes_to_hex(data.data(), data.size());
-    done += chunk;
-  }
-  return hex;
-}
-
-std::string RspHandler::handle_memory_write(const std::string &packet) {
-  /* Maddr,length:XX... */
-  if (!ensure_attached()) return err_packet(1);
-  const size_t comma = packet.find(',');
-  const size_t colon = packet.find(':');
-  if (comma == std::string::npos || colon == std::string::npos || colon < comma)
-    return err_packet(1);
-  uint64_t addr = 0U;
-  uint64_t length = 0U;
-  if (!parse_hex_u64(packet, 1U, comma, addr)) return err_packet(1);
-  if (!parse_hex_u64(packet, comma + 1U, colon, length)) return err_packet(1);
-  const std::string hex = packet.substr(colon + 1U);
-  if (hex.size() != length * 2U) return err_packet(1);
-  std::vector<uint8_t> data(static_cast<size_t>(length));
-  if (length > 0U &&
-      !hex_to_bytes(hex, data.data(), static_cast<size_t>(length))) {
-    return err_packet(1);
-  }
-  uint32_t written = 0U;
-  if (!client_.memory_write(pid_, addr, data, written) ||
-      written != static_cast<uint32_t>(length)) {
-    return err_packet(1);
-  }
-  return "OK";
-}
-
-std::string RspHandler::handle_breakpoint(const std::string &packet,
-                                          bool enable) {
-  /* Ztype,addr,kind  / ztype,addr,kind */
-  if (!ensure_attached()) return err_packet(1);
-  if (packet.size() < 5U) return err_packet(1);
-  const char type = packet[1];
-  const size_t comma1 = packet.find(',', 2U);
-  if (comma1 == std::string::npos) return err_packet(1);
-  size_t comma2 = packet.find(',', comma1 + 1U);
-  if (comma2 == std::string::npos) comma2 = packet.size();
-  uint64_t addr = 0U;
-  uint64_t kind = 1U;
-  if (!parse_hex_u64(packet, comma1 + 1U, comma2, addr)) return err_packet(1);
-  if (comma2 < packet.size()) {
-    (void)parse_hex_u64(packet, comma2 + 1U, packet.size(), kind);
-  }
-  (void)kind;
-
-  if (type == '0') {
-    if (enable) {
-      if (!client_.debug_set_breakpoint(addr, 0U)) return err_packet(1);
-    } else {
-      if (!client_.debug_clear_breakpoint(addr)) return err_packet(1);
-    }
-    return "OK";
-  }
-  if (type == '1') {
-    if (enable) {
-      if (!client_.debug_set_breakpoint(addr, 1U)) return err_packet(1);
-    } else {
-      if (!client_.debug_clear_breakpoint(addr)) return err_packet(1);
-    }
-    return "OK";
-  }
-  const int wtype = watch_type_from_z(type);
-  if (wtype < 0) return std::string(); /* unsupported */
-  const uint32_t length = kind == 0U ? 1U : static_cast<uint32_t>(kind);
-  if (enable) {
-    if (!client_.debug_set_watchpoint(addr, length,
-                                      static_cast<uint32_t>(wtype))) {
-      return err_packet(1);
-    }
-  } else {
-    if (!client_.debug_clear_watchpoint(addr)) return err_packet(1);
-  }
-  return "OK";
-}
-
-std::string RspHandler::handle_query(const std::string &packet,
-                                     RspConnection &conn) {
-  if (packet.rfind("qSupported", 0) == 0) {
-    return "PacketSize=1048576;qXfer:features:read+;qXfer:memory-map:read+;"
-           "swbreak+;hwbreak+;QStartNoAckMode+";
-  }
-  if (packet == "QStartNoAckMode") {
-    conn.set_no_ack(true);
-    return "OK";
-  }
-  if (packet == "qAttached") return attached_ ? "1" : "0";
-  if (packet.rfind("qAttached:", 0) == 0) return attached_ ? "1" : "0";
-  if (packet == "qProcessInfo" || packet.rfind("qProcessInfo:", 0) == 0) {
-    char buf[128];
-    std::snprintf(buf, sizeof(buf),
-                  "pid:%x;triple:x86_64-unknown-freebsd;endian:little;",
-                  static_cast<unsigned>(pid_ > 0 ? pid_ : 1));
-    return std::string(buf);
-  }
-  if (packet == "qC") {
-    char buf[32];
-    std::snprintf(buf, sizeof(buf), "QC%x",
-                  static_cast<unsigned>(current_thread()));
-    return std::string(buf);
-  }
-  if (packet == "qfThreadInfo") {
-    refresh_threads();
-    thread_info_started_ = true;
-    if (threads_.empty()) {
-      if (pid_ > 0) {
-        char buf[16];
-        std::snprintf(buf, sizeof(buf), "m%x", static_cast<unsigned>(pid_));
-        return std::string(buf);
-      }
-      return "l";
-    }
-    std::string out = "m";
-    for (size_t i = 0; i < threads_.size(); ++i) {
-      if (i > 0U) out.push_back(',');
-      char buf[16];
-      std::snprintf(buf, sizeof(buf), "%x",
-                    static_cast<unsigned>(threads_[i].lwp > 0 ? threads_[i].lwp : pid_));
-      out += buf;
-    }
-    return out;
-  }
-  if (packet == "qsThreadInfo") return "l";
-  if (packet.rfind("qThreadExtraInfo,", 0) == 0) {
-    int32_t req_pid = 0, req_tid = 0;
-    if (!parse_thread_id(packet.c_str() + std::strlen("qThreadExtraInfo,"),
-                         req_pid, req_tid)) {
-      return err_packet(1);
-    }
-    refresh_threads();
-    for (const auto &t : threads_) {
-      if (t.lwp == req_tid || (req_tid <= 0 && t.lwp > 0)) {
-        return gdb_thread_extra_info_hex(t.lwp, t.name);
-      }
-    }
-    const int32_t fallback_tid = req_tid > 0 ? req_tid : (pid_ > 0 ? pid_ : 1);
-    return gdb_thread_extra_info_hex(fallback_tid, "");
-  }
-  if (packet.rfind("qXfer:features:read:", 0) == 0) {
-    /* qXfer:features:read:annex:offset,length */
-    const std::string rest = packet.substr(std::strlen("qXfer:features:read:"));
-    const size_t colon = rest.find(':');
-    if (colon == std::string::npos) return err_packet(1);
-    const std::string annex = rest.substr(0U, colon);
-    const size_t comma = rest.find(',', colon + 1U);
-    if (comma == std::string::npos) return err_packet(1);
-    uint64_t offset = 0U;
-    uint64_t length = 0U;
-    if (!parse_hex_u64(rest, colon + 1U, comma, offset)) return err_packet(1);
-    if (!parse_hex_u64(rest, comma + 1U, rest.size(), length))
-      return err_packet(1);
-    return qxfer_features(annex, static_cast<size_t>(offset),
-                          static_cast<size_t>(length));
-  }
-  if (packet.rfind("qXfer:memory-map:read:", 0) == 0) {
-    /* qXfer:memory-map:read::offset,length  (empty annex) */
-    const std::string rest =
-        packet.substr(std::strlen("qXfer:memory-map:read:"));
-    const size_t colon = rest.find(':');
-    if (colon == std::string::npos) return err_packet(1);
-    const size_t comma = rest.find(',', colon + 1U);
-    if (comma == std::string::npos) return err_packet(1);
-    uint64_t offset = 0U;
-    uint64_t length = 0U;
-    if (!parse_hex_u64(rest, colon + 1U, comma, offset)) return err_packet(1);
-    if (!parse_hex_u64(rest, comma + 1U, rest.size(), length))
-      return err_packet(1);
-    return qxfer_memory_map(static_cast<size_t>(offset),
-                            static_cast<size_t>(length));
-  }
-  if (packet.rfind("qRcmd,", 0) == 0) {
-    return "OK";
-  }
-  return std::string(); /* unsupported query */
-}
-
-std::string RspHandler::handle_v(const std::string &packet,
-                                 RspConnection &conn) {
-  if (packet.rfind("vAttach;", 0) == 0) {
-    int32_t req_pid = 0, req_tid = 0;
-    if (!parse_thread_id(packet.c_str() + 8, req_pid, req_tid)) {
-      logf("vAttach: bad pid hex in '%s'", packet.c_str());
-      return err_packet(1);
-    }
-    const int32_t attach_pid = req_pid > 0 ? req_pid : req_tid;
-    logf("vAttach pid=0x%x (%d decimal)", static_cast<unsigned>(attach_pid),
-         static_cast<int>(attach_pid));
-    if (attached_ && pid_ == attach_pid) {
-      logf("vAttach: reusing session for pid=%d", static_cast<int>(pid_));
-      return stop_reply();
-    }
-    if (attached_) {
-      logf("vAttach: switching from pid=%d", static_cast<int>(pid_));
-      if (!safe_detach()) return err_packet(1);
-    }
-    pid_ = attach_pid;
-    if (!client_.debug_attach(pid_)) {
-      logf("vAttach debug_attach failed: %s", client_.last_error().c_str());
-      return err_packet(1);
-    }
-    attached_ = true;
-    refresh_threads();
-    if (!threads_.empty()) {
-      stop_lwp_ = threads_[0].lwp;
-      general_thread_ = stop_lwp_;
-    }
-    return stop_reply();
-  }
-  if (packet == "vCont?") {
-    return "vCont;c;C;s;S";
-  }
-  if (packet.rfind("vCont;", 0) == 0) {
-    /* Support first action only (all-stop MVP). */
-    const char action = packet.size() > 6U ? packet[6] : '\0';
-    int32_t lwp = 0;
-    const size_t colon = packet.find(':', 6U);
-    if (colon != std::string::npos) {
-      int32_t p_out = 0, t_out = 0;
-      if (parse_thread_id(packet.c_str() + colon + 1U, p_out, t_out)) {
-        lwp = t_out > 0 ? t_out : 0;
-      }
-    }
-    if (action == 'c' || action == 'C') {
-      return handle_continue_or_step(false, conn, lwp);
-    }
-    if (action == 's' || action == 'S') {
-      return handle_continue_or_step(true, conn, lwp);
-    }
-    return err_packet(1);
-  }
-  if (packet == "vMustReplyEmpty") return std::string();
-  return std::string();
 }
 
 std::string RspHandler::handle(const std::string &packet, RspConnection &conn) {
@@ -592,8 +154,10 @@ std::string RspHandler::handle(const std::string &packet, RspConnection &conn) {
     reply = handle_v(packet, conn);
   } else if (packet == "?") {
     if (!attached_ && pid_ > 0) {
-      if (!ensure_attached()) reply = "W00";
-      else reply = stop_reply();
+      if (!ensure_attached())
+        reply = "W00";
+      else
+        reply = stop_reply();
     } else {
       reply = attached_ ? stop_reply() : "W00";
     }
@@ -611,7 +175,26 @@ std::string RspHandler::handle(const std::string &packet, RspConnection &conn) {
         if (!parse_thread_id(packet.c_str() + 2, req_pid, req_tid)) {
           reply = err_packet(1);
         } else {
-          if (which == 'g') {
+          if (req_pid > 0 && pid_ > 0 && req_pid != pid_) {
+            reply = err_packet(1);
+          } else if (attached_ && req_tid > 0) {
+            refresh_threads();
+            const bool exists = req_tid == pid_ || std::any_of(threads_.begin(), threads_.end(),
+                                                               [&](const auto &thread) {
+                                                                 return thread.lwp == req_tid;
+                                                               });
+            if (!exists) {
+              reply = err_packet(1);
+            } else if (which == 'g') {
+              general_thread_ = req_tid;
+              reply = "OK";
+            } else if (which == 'c') {
+              continue_thread_ = req_tid;
+              reply = "OK";
+            } else {
+              reply = std::string();
+            }
+          } else if (which == 'g') {
             general_thread_ = req_tid;
             reply = "OK";
           } else if (which == 'c') {
@@ -622,137 +205,44 @@ std::string RspHandler::handle(const std::string &packet, RspConnection &conn) {
           }
         }
       }
-    } else if (packet[0] == 'g') {
-      if (!ensure_attached()) {
-        reply = err_packet(1);
-      } else {
-        memdbg::frontend::Client::DebugRegs regs;
-        if (!client_.debug_get_regs(current_thread(), regs)) {
-          reply = err_packet(1);
-        } else {
-          /* IDA's Remote GDB debugger is interoperable with the PS4 reference
-           * gdbsrv when the bulk register packet contains the 24 amd64 core
-           * registers only.  Optional FP/SSE state remains available through
-           * individual p/P packets, but must not shift IDA's core layout. */
-          reply = gdb_encode_g_core(regs.regs);
-        }
-      }
+    } else if (packet == "g") {
+      reply = handle_read_all_registers();
     } else if (packet[0] == 'G') {
-      if (!ensure_attached()) {
-        reply = err_packet(1);
-      } else {
-        memdbg::frontend::Client::DebugRegs regs;
-        if (!client_.debug_get_regs(current_thread(), regs)) {
-          reply = err_packet(1);
-        } else {
-          if (!gdb_decode_g_core(packet.substr(1U), regs.regs))
-            reply = err_packet(1);
-          else if (!client_.debug_set_regs(current_thread(), regs))
-            reply = err_packet(1);
-          else
-            reply = "OK";
-        }
-      }
+      reply = handle_write_all_registers(packet);
     } else if (packet[0] == 'p') {
-      if (!ensure_attached()) {
-        reply = err_packet(1);
-      } else {
-        uint64_t regno = 0U;
-        if (!parse_hex_u64(packet.c_str() + 1, regno) ||
-            !gdb_reg_valid(static_cast<int>(regno))) {
-          reply = err_packet(1);
-        } else {
-          const int ir = static_cast<int>(regno);
-          const size_t size = gdb_reg_size(ir);
-          if (gdb_reg_is_sse(ir)) {
-            memdbg::frontend::Client::DebugFpregs fpregs;
-            if (!client_.debug_get_fpregs(current_thread(), fpregs))
-              reply = err_packet(1);
-            else {
-              uint8_t buf[16]{};
-              if (!gdb_get_sse_bytes(fpregs.fpregs, ir, buf, sizeof(buf)))
-                reply = err_packet(1);
-              else
-                reply = bytes_to_hex(buf, size);
-            }
-          } else {
-            memdbg::frontend::Client::DebugRegs regs;
-            if (!client_.debug_get_regs(current_thread(), regs)) {
-              reply = err_packet(1);
-            } else {
-              uint64_t value = gdb_get_reg_value(regs.regs, ir);
-              if (size == 4U) value &= 0xFFFFFFFFULL;
-              reply = bytes_to_hex(&value, size);
-            }
-          }
-        }
-      }
+      reply = handle_read_register(packet);
     } else if (packet[0] == 'P') {
-      if (!ensure_attached()) {
-        reply = err_packet(1);
-      } else {
-        const size_t eq = packet.find('=');
-        if (eq == std::string::npos) {
-          reply = err_packet(1);
-        } else {
-          uint64_t regno = 0U;
-          if (!parse_hex_u64(packet, 1U, eq, regno) ||
-              !gdb_reg_valid(static_cast<int>(regno))) {
-            reply = err_packet(1);
-          } else {
-            const int ir = static_cast<int>(regno);
-            const size_t size = gdb_reg_size(ir);
-            if (gdb_reg_is_sse(ir)) {
-              uint8_t buf[16]{};
-              if (!hex_to_bytes(packet.substr(eq + 1U), buf, size))
-                reply = err_packet(1);
-              else {
-                memdbg::frontend::Client::DebugFpregs fpregs;
-                (void)client_.debug_get_fpregs(current_thread(), fpregs);
-                if (!gdb_set_sse_bytes(fpregs.fpregs, ir, buf, size))
-                  reply = err_packet(1);
-                else if (!client_.debug_set_fpregs(current_thread(), fpregs))
-                  reply = err_packet(1);
-                else
-                  reply = "OK";
-              }
-            } else {
-              uint64_t value = 0U;
-              if (!hex_to_bytes(packet.substr(eq + 1U), &value, size))
-                reply = err_packet(1);
-              else {
-                memdbg::frontend::Client::DebugRegs regs;
-                if (!client_.debug_get_regs(current_thread(), regs))
-                  reply = err_packet(1);
-                else if (!gdb_set_reg_value(regs.regs, ir, value))
-                  reply = err_packet(1);
-                else if (!client_.debug_set_regs(current_thread(), regs))
-                  reply = err_packet(1);
-                else
-                  reply = "OK";
-              }
-            }
-          }
-        }
-      }
+      reply = handle_write_register(packet);
     } else if (packet[0] == 'm') {
       reply = handle_memory_read(packet);
     } else if (packet[0] == 'M') {
       reply = handle_memory_write(packet);
+    } else if (packet[0] == 'X') {
+      reply = handle_binary_memory_write(packet);
     } else if (packet[0] == 'c' || packet[0] == 'C') {
-      reply = handle_continue_or_step(false, conn, continue_thread_);
+      reply = handle_resume_packet(packet, false, conn);
     } else if (packet[0] == 's' || packet[0] == 'S') {
-      reply = handle_continue_or_step(true, conn, continue_thread_);
+      reply = handle_resume_packet(packet, true, conn);
     } else if (packet[0] == 'Z') {
       reply = handle_breakpoint(packet, true);
     } else if (packet[0] == 'z') {
       reply = handle_breakpoint(packet, false);
-    } else if (packet[0] == 'D' || packet == "k") {
-      reply = safe_detach() ? "OK" : err_packet(1);
+    } else if (packet[0] == 'D') {
+      bool valid_detach = packet == "D";
+      if (!valid_detach && packet.rfind("D;", 0U) == 0U) {
+        uint64_t detach_pid = 0U;
+        valid_detach = detail::parse_hex_u64(packet, 2U, packet.size(), detach_pid) &&
+                       detach_pid == static_cast<uint64_t>(pid_);
+      }
+      reply = valid_detach && safe_detach() ? "OK" : err_packet(1);
+    } else if (packet == "k") {
+      reply = attached_ && kill_process(pid_) ? "OK" : err_packet(1);
     } else if (packet[0] == 'T') {
       refresh_threads();
       int32_t req_pid = 0, req_tid = 0;
       if (!parse_thread_id(packet.c_str() + 1, req_pid, req_tid)) {
+        reply = err_packet(1);
+      } else if (req_pid > 0 && req_pid != pid_) {
         reply = err_packet(1);
       } else {
         reply = err_packet(1);

--- a/tools/gdb_bridge/rsp_handler.hpp
+++ b/tools/gdb_bridge/rsp_handler.hpp
@@ -7,28 +7,21 @@
 #ifndef MEMDBG_GDB_BRIDGE_RSP_HANDLER_HPP
 #define MEMDBG_GDB_BRIDGE_RSP_HANDLER_HPP
 
-#include "memdbg_client.hpp"
+#include "rsp_backend.hpp"
+#include "rsp_protocol.hpp"
 #include "rsp_server.hpp"
 
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace memdbg::gdb_bridge {
 
-/* Thread ID parser supporting multiprocess RSP syntax (p<pid>.<tid>, p<pid>, <tid>). */
-bool parse_thread_id(const char *s, int32_t &pid_out, int32_t &tid_out);
-
-/* Convert x86 DR6 B0..B3 plus the installed slot metadata into the GDB RSP
- * stop-reason field (watch/rwatch/awatch/hwbreak). */
-std::string gdb_watchpoint_stop_field(
-    uint64_t dr6,
-    const std::vector<memdbg::frontend::Client::DebugWatchpointEntry> &entries);
-
 class RspHandler {
 public:
-  RspHandler(memdbg::frontend::Client &client, int32_t initial_pid,
-             bool verbose = false);
+  RspHandler(memdbg::frontend::Client &client, int32_t initial_pid, bool verbose = false);
+  RspHandler(RspBackend &backend, int32_t initial_pid, bool verbose = false);
 
   std::string handle(const std::string &packet, RspConnection &conn);
 
@@ -44,12 +37,24 @@ private:
   std::string handle_memory_read(const std::string &packet);
   std::string handle_memory_write(const std::string &packet);
   std::string handle_breakpoint(const std::string &packet, bool enable);
-  std::string handle_continue_or_step(bool step, RspConnection &conn,
-                                      int32_t lwp);
+  std::string handle_continue_or_step(bool step, RspConnection &conn, int32_t lwp);
   std::string stop_reply() const;
-  std::string qxfer_features(const std::string &annex, size_t offset,
-                             size_t length) const;
+  std::string qxfer_features(const std::string &annex, size_t offset, size_t length) const;
   std::string qxfer_memory_map(size_t offset, size_t length);
+  std::string qxfer_threads(size_t offset, size_t length);
+  std::string qxfer_libraries(size_t offset, size_t length);
+  std::string qxfer_exec_file(size_t offset, size_t length);
+  std::string qxfer_osdata(const std::string &annex, size_t offset, size_t length);
+  std::string handle_binary_memory_write(const std::string &packet);
+  std::string handle_search_memory(const std::string &packet);
+  std::string handle_read_all_registers();
+  std::string handle_write_all_registers(const std::string &packet);
+  std::string handle_read_register(const std::string &packet);
+  std::string handle_write_register(const std::string &packet);
+  std::string handle_resume_packet(const std::string &packet, bool step, RspConnection &conn);
+  std::string memory_region_info(const std::string &packet);
+  bool set_program_counter(uint64_t address);
+  bool kill_process(int32_t target_pid);
   bool ensure_attached();
   bool safe_detach();
   void logf(const char *fmt, ...) const;
@@ -57,17 +62,22 @@ private:
   void capture_stop_reason(int32_t lwp);
   int32_t current_thread() const;
   void refresh_threads();
+  bool refresh_memory_maps();
 
-  memdbg::frontend::Client &client_;
+  std::unique_ptr<RspBackend> owned_backend_;
+  RspBackend &backend_;
   int32_t pid_ = 0;
   bool attached_ = false;
   bool verbose_ = false;
   int32_t general_thread_ = 0; /* Hg */
   int32_t continue_thread_ = 0; /* Hc; 0 = all */
   int32_t stop_lwp_ = 0;
+  uint8_t stop_signal_ = 5U; /* SIGTRAP */
   std::string stop_reason_;
   bool thread_info_started_ = false;
   std::vector<memdbg::frontend::Client::DebugThreadEntry> threads_;
+  std::vector<memdbg::frontend::MapEntry> memory_maps_;
+  bool memory_maps_known_ = false;
 };
 
 } // namespace memdbg::gdb_bridge

--- a/tools/gdb_bridge/rsp_handler_memory.cpp
+++ b/tools/gdb_bridge/rsp_handler_memory.cpp
@@ -1,0 +1,174 @@
+/*
+ * MemDBG - GDB RSP memory packet handling.
+ * Copyright (C) 2026 SeregonWar
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "rsp_handler.hpp"
+
+#include "gdb_regs.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdio>
+#include <cstring>
+#include <limits>
+#include <string>
+#include <vector>
+
+namespace memdbg::gdb_bridge {
+
+using namespace detail;
+
+std::string RspHandler::handle_memory_read(const std::string &packet) {
+  /* maddr,length */
+  if (!ensure_attached()) return err_packet(1);
+  const size_t comma = packet.find(',');
+  if (comma == std::string::npos) return err_packet(1);
+  uint64_t addr = 0U;
+  uint64_t length = 0U;
+  if (!parse_hex_u64(packet, 1U, comma, addr)) return err_packet(1);
+  if (!parse_hex_u64(packet, comma + 1U, packet.size(), length)) return err_packet(1);
+  if (length == 0U) return std::string();
+  if (length > kRspMaxMemory || addr > std::numeric_limits<uint64_t>::max() - length) {
+    return err_packet(0x22);
+  }
+  if (memory_maps_known_ && !gdb_memory_range_mapped(memory_maps_, addr, length)) {
+    logf("rejecting unmapped memory read addr=0x%llx length=0x%llx",
+         static_cast<unsigned long long>(addr), static_cast<unsigned long long>(length));
+    return err_packet(1);
+  }
+
+  std::string hex;
+  hex.reserve(static_cast<size_t>(length) * 2U);
+  uint64_t done = 0U;
+  while (done < length) {
+    uint32_t chunk = static_cast<uint32_t>(length - done);
+    if (chunk > kMemChunk) chunk = kMemChunk;
+    std::vector<uint8_t> data;
+    if (!backend_.memory_read(pid_, addr + done, chunk, data) || data.size() != chunk) {
+      return err_packet(1);
+    }
+    hex += bytes_to_hex(data.data(), data.size());
+    done += chunk;
+  }
+  return hex;
+}
+
+std::string RspHandler::handle_memory_write(const std::string &packet) {
+  /* Maddr,length:XX... */
+  if (!ensure_attached()) return err_packet(1);
+  const size_t comma = packet.find(',');
+  const size_t colon = packet.find(':');
+  if (comma == std::string::npos || colon == std::string::npos || colon < comma)
+    return err_packet(1);
+  uint64_t addr = 0U;
+  uint64_t length = 0U;
+  if (!parse_hex_u64(packet, 1U, comma, addr)) return err_packet(1);
+  if (!parse_hex_u64(packet, comma + 1U, colon, length)) return err_packet(1);
+  if (length > kRspMaxMemory || addr > std::numeric_limits<uint64_t>::max() - length ||
+      length > std::numeric_limits<size_t>::max() / 2U) {
+    return err_packet(0x22);
+  }
+  if (memory_maps_known_ && !gdb_memory_range_mapped(memory_maps_, addr, length)) {
+    return err_packet(1);
+  }
+  const std::string hex = packet.substr(colon + 1U);
+  if (hex.size() != static_cast<size_t>(length) * 2U) return err_packet(1);
+  std::vector<uint8_t> data(static_cast<size_t>(length));
+  if (length > 0U && !hex_to_bytes(hex, data.data(), static_cast<size_t>(length))) {
+    return err_packet(1);
+  }
+  uint32_t written = 0U;
+  if (!backend_.memory_write(pid_, addr, data, written) ||
+      written != static_cast<uint32_t>(length)) {
+    return err_packet(1);
+  }
+  return "OK";
+}
+
+std::string RspHandler::handle_binary_memory_write(const std::string &packet) {
+  /* Xaddr,length:<binary data>; RspConnection already unescaped it. */
+  if (!ensure_attached()) return err_packet(1);
+  const size_t comma = packet.find(',');
+  const size_t colon = packet.find(':');
+  if (comma == std::string::npos || colon == std::string::npos || comma <= 1U ||
+      colon <= comma + 1U) {
+    return err_packet(1);
+  }
+  uint64_t addr = 0U;
+  uint64_t length = 0U;
+  if (!parse_hex_u64(packet, 1U, comma, addr) ||
+      !parse_hex_u64(packet, comma + 1U, colon, length)) {
+    return err_packet(1);
+  }
+  if (length > kRspMaxMemory || addr > std::numeric_limits<uint64_t>::max() - length ||
+      length > std::numeric_limits<size_t>::max()) {
+    return err_packet(0x22);
+  }
+  if (memory_maps_known_ && !gdb_memory_range_mapped(memory_maps_, addr, length)) {
+    return err_packet(1);
+  }
+  const size_t byte_length = static_cast<size_t>(length);
+  if (packet.size() - colon - 1U != byte_length) return err_packet(1);
+  std::vector<uint8_t> data(byte_length);
+  if (byte_length > 0U) { std::memcpy(data.data(), packet.data() + colon + 1U, byte_length); }
+  uint32_t written = 0U;
+  if (!backend_.memory_write(pid_, addr, data, written) || written != byte_length) {
+    return err_packet(1);
+  }
+  return "OK";
+}
+
+std::string RspHandler::handle_search_memory(const std::string &packet) {
+  static constexpr const char *kPrefix = "qSearch:memory:";
+  if (!ensure_attached() || packet.rfind(kPrefix, 0U) != 0U) return err_packet(1);
+  const size_t begin = std::strlen(kPrefix);
+  const size_t semi1 = packet.find(';', begin);
+  const size_t semi2 =
+    semi1 == std::string::npos ? std::string::npos : packet.find(';', semi1 + 1U);
+  if (semi1 == std::string::npos || semi2 == std::string::npos) return err_packet(1);
+  uint64_t address = 0U;
+  uint64_t length = 0U;
+  if (!parse_hex_u64(packet, begin, semi1, address) ||
+      !parse_hex_u64(packet, semi1 + 1U, semi2, length) || length > 0x4000000U ||
+      address > std::numeric_limits<uint64_t>::max() - length) {
+    return err_packet(0x22);
+  }
+  const std::string pattern_text = packet.substr(semi2 + 1U);
+  const std::vector<uint8_t> pattern(pattern_text.begin(), pattern_text.end());
+  if (pattern.empty() || pattern.size() > 0x1000U || pattern.size() > length ||
+      (memory_maps_known_ && !gdb_memory_range_mapped(memory_maps_, address, length))) {
+    return pattern.size() > length ? "0" : err_packet(1);
+  }
+
+  const size_t overlap = pattern.size() - 1U;
+  uint64_t cursor = address;
+  std::vector<uint8_t> carry;
+  while (cursor < address + length) {
+    const uint32_t amount =
+      static_cast<uint32_t>(std::min<uint64_t>(kMemChunk, address + length - cursor));
+    std::vector<uint8_t> data;
+    if (!backend_.memory_read(pid_, cursor, amount, data) || data.size() != amount) {
+      return err_packet(1);
+    }
+    std::vector<uint8_t> window;
+    window.reserve(carry.size() + data.size());
+    window.insert(window.end(), carry.begin(), carry.end());
+    window.insert(window.end(), data.begin(), data.end());
+    const auto hit = std::search(window.begin(), window.end(), pattern.begin(), pattern.end());
+    if (hit != window.end()) {
+      const uint64_t base = cursor - carry.size();
+      const uint64_t found = base + static_cast<uint64_t>(std::distance(window.begin(), hit));
+      char reply[40];
+      std::snprintf(reply, sizeof(reply), "1,%llx", static_cast<unsigned long long>(found));
+      return std::string(reply);
+    }
+    const size_t keep = std::min(overlap, window.size());
+    carry.assign(window.end() - static_cast<std::ptrdiff_t>(keep), window.end());
+    cursor += amount;
+  }
+  return "0";
+}
+
+} // namespace memdbg::gdb_bridge

--- a/tools/gdb_bridge/rsp_handler_query.cpp
+++ b/tools/gdb_bridge/rsp_handler_query.cpp
@@ -1,0 +1,308 @@
+/*
+ * MemDBG - GDB RSP query and XML transfer handling.
+ * Copyright (C) 2026 SeregonWar
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "rsp_handler.hpp"
+
+#include "gdb_regs.hpp"
+#include "target_xml.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+#include <limits>
+#include <string>
+#include <vector>
+
+namespace memdbg::gdb_bridge {
+
+using namespace detail;
+
+std::string RspHandler::qxfer_features(const std::string &annex, size_t offset,
+                                       size_t length) const {
+  if (annex != "target.xml") return err_packet(1);
+  return qxfer_slice(kMemdbgGdbTargetXml, offset, length);
+}
+
+std::string RspHandler::qxfer_memory_map(size_t offset, size_t length) {
+  if (!ensure_attached()) return err_packet(1);
+  if ((offset == 0U || !memory_maps_known_) && !refresh_memory_maps()) return err_packet(1);
+
+  std::string xml = "<?xml version=\"1.0\"?>"
+                    "<!DOCTYPE memory-map PUBLIC "
+                    "\"+//IDN gnu.org/DTD GDB Memory Map V1.0//EN\" "
+                    "\"http://sourceware.org/gdb/gdb-memory-map.dtd\">"
+                    "<memory-map>";
+  for (const auto &m : memory_maps_) {
+    if (m.end <= m.start) continue;
+    const uint64_t len = m.end - m.start;
+    char buf[128];
+    std::snprintf(buf, sizeof(buf), "<memory type=\"ram\" start=\"0x%llx\" length=\"0x%llx\"/>",
+                  static_cast<unsigned long long>(m.start), static_cast<unsigned long long>(len));
+    xml += buf;
+  }
+  xml += "</memory-map>";
+
+  return qxfer_slice(xml, offset, length);
+}
+
+std::string RspHandler::qxfer_threads(size_t offset, size_t length) {
+  if (!ensure_attached()) return err_packet(1);
+  if (offset == 0U) refresh_threads();
+  std::string xml = "<?xml version=\"1.0\"?><threads>";
+  if (threads_.empty() && pid_ > 0) {
+    char buf[96];
+    std::snprintf(buf, sizeof(buf), "<thread id=\"%x\" name=\"main (fallback)\"/>",
+                  static_cast<unsigned>(pid_));
+    xml += buf;
+  } else {
+    for (const auto &thread : threads_) {
+      if (thread.lwp <= 0) continue;
+      char buf[48];
+      std::snprintf(buf, sizeof(buf), "<thread id=\"%x\" name=\"",
+                    static_cast<unsigned>(thread.lwp));
+      xml += buf;
+      xml += xml_escape(thread.name.empty() ? "LWP " + std::to_string(thread.lwp) : thread.name);
+      xml += "\"/>";
+    }
+  }
+  xml += "</threads>";
+  return qxfer_slice(xml, offset, length);
+}
+
+std::string RspHandler::qxfer_libraries(size_t offset, size_t length) {
+  if (!ensure_attached()) return err_packet(1);
+  if ((offset == 0U || !memory_maps_known_) && !refresh_memory_maps()) return err_packet(1);
+
+  std::string xml = "<?xml version=\"1.0\"?><library-list>";
+  std::vector<std::string> emitted;
+  for (const auto &map : memory_maps_) {
+    if (map.end <= map.start || map.name.empty() ||
+        std::find(emitted.begin(), emitted.end(), map.name) != emitted.end()) {
+      continue;
+    }
+    emitted.push_back(map.name);
+    xml += "<library name=\"" + xml_escape(map.name) + "\">";
+    for (const auto &segment : memory_maps_) {
+      if (segment.name != map.name || segment.end <= segment.start) continue;
+      char buf[64];
+      std::snprintf(buf, sizeof(buf), "<segment address=\"0x%llx\"/>",
+                    static_cast<unsigned long long>(segment.start));
+      xml += buf;
+    }
+    xml += "</library>";
+  }
+  xml += "</library-list>";
+  return qxfer_slice(xml, offset, length);
+}
+
+std::string RspHandler::qxfer_exec_file(size_t offset, size_t length) {
+  if (!ensure_attached()) return err_packet(1);
+  memdbg::frontend::ProcessInfo info;
+  if (!backend_.process_info(pid_, info)) return err_packet(1);
+  const std::string path = !info.path.empty() ? info.path : info.name;
+  return qxfer_slice(path, offset, length);
+}
+
+std::string RspHandler::qxfer_osdata(const std::string &annex, size_t offset, size_t length) {
+  if (annex != "processes") return err_packet(1);
+  std::vector<memdbg::frontend::ProcessEntry> processes;
+  if (!backend_.process_list(processes)) return err_packet(1);
+  std::string xml = "<?xml version=\"1.0\"?><osdata type=\"processes\">";
+  for (const auto &process : processes) {
+    xml += "<item><column name=\"pid\">" + std::to_string(process.pid) +
+           "</column><column name=\"ppid\">" + std::to_string(process.ppid) +
+           "</column><column name=\"command\">" + xml_escape(process.name) + "</column></item>";
+  }
+  xml += "</osdata>";
+  return qxfer_slice(xml, offset, length);
+}
+
+std::string RspHandler::memory_region_info(const std::string &packet) {
+  static constexpr const char *kPrefix = "qMemoryRegionInfo:";
+  if (!ensure_attached() || packet.rfind(kPrefix, 0U) != 0U) return err_packet(1);
+  uint64_t address = 0U;
+  if (!parse_hex_u64(packet.c_str() + std::strlen(kPrefix), address)) return err_packet(1);
+  if (!memory_maps_known_ && !refresh_memory_maps()) return err_packet(1);
+
+  for (const auto &map : memory_maps_) {
+    if (map.start <= address && address < map.end) {
+      std::string permissions;
+      if ((map.protection & MEMDBG_MAP_PROT_READ) != 0U) permissions += 'r';
+      if ((map.protection & MEMDBG_MAP_PROT_WRITE) != 0U) permissions += 'w';
+      if ((map.protection & MEMDBG_MAP_PROT_EXEC) != 0U) permissions += 'x';
+      char reply[128];
+      std::snprintf(reply, sizeof(reply), "start:%llx;size:%llx;permissions:%s;",
+                    static_cast<unsigned long long>(map.start),
+                    static_cast<unsigned long long>(map.end - map.start), permissions.c_str());
+      std::string out(reply);
+      if (!map.name.empty()) out += "name:" + bytes_to_hex(map.name.data(), map.name.size()) + ";";
+      return out;
+    }
+  }
+
+  uint64_t next = std::numeric_limits<uint64_t>::max();
+  for (const auto &map : memory_maps_) {
+    if (map.start > address && map.start < next) next = map.start;
+  }
+  const uint64_t size = next == std::numeric_limits<uint64_t>::max()
+                          ? std::numeric_limits<uint64_t>::max() - address
+                          : next - address;
+  char reply[96];
+  std::snprintf(reply, sizeof(reply), "start:%llx;size:%llx;permissions:;",
+                static_cast<unsigned long long>(address), static_cast<unsigned long long>(size));
+  return std::string(reply);
+}
+
+std::string RspHandler::handle_query(const std::string &packet, RspConnection &conn) {
+  if (packet.rfind("qSupported", 0) == 0) {
+    return "PacketSize=200000;qXfer:features:read+;"
+           "qXfer:memory-map:read+;qXfer:threads:read+;"
+           "qXfer:libraries:read+;qXfer:exec-file:read+;"
+           "qXfer:osdata:read+;swbreak+;hwbreak+;"
+           "QStartNoAckMode+;vContSupported+";
+  }
+  if (packet == "QStartNoAckMode") {
+    conn.set_no_ack(true);
+    return "OK";
+  }
+  if (packet == "QNonStop:0" || packet == "QThreadEvents:0" || packet == "QThreadEvents:1")
+    return "OK";
+  if (packet == "QNonStop:1") return err_packet(1);
+  if (packet == "qAttached") return attached_ ? "1" : "0";
+  if (packet.rfind("qAttached:", 0) == 0) {
+    uint64_t requested_pid = 0U;
+    if (!parse_hex_u64(packet, std::strlen("qAttached:"), packet.size(), requested_pid)) {
+      return err_packet(1);
+    }
+    return attached_ && requested_pid == static_cast<uint64_t>(pid_) ? "1" : "0";
+  }
+  if (packet == "qProcessInfo" || packet.rfind("qProcessInfo:", 0) == 0) {
+    char buf[128];
+    std::snprintf(buf, sizeof(buf), "pid:%x;triple:x86_64-unknown-freebsd;endian:little;",
+                  static_cast<unsigned>(pid_ > 0 ? pid_ : 1));
+    return std::string(buf);
+  }
+  if (packet == "qC") {
+    char buf[32];
+    std::snprintf(buf, sizeof(buf), "QC%x", static_cast<unsigned>(current_thread()));
+    return std::string(buf);
+  }
+  if (packet == "qHostInfo") {
+    return "triple:7838365f36342d756e6b6e6f776e2d66726565627364;"
+           "endian:little;ptrsize:8;";
+  }
+  if (packet == "qOffsets") return "Text=0;Data=0;Bss=0";
+  if (packet == "qSymbol::" || packet.rfind("qSymbol:", 0U) == 0U) return "OK";
+  if (packet == "qTStatus" || packet == "qTfV" || packet == "qTsV") return std::string();
+  if (packet.rfind("qMemoryRegionInfo:", 0U) == 0U) return memory_region_info(packet);
+  if (packet.rfind("qSearch:memory:", 0U) == 0U) return handle_search_memory(packet);
+  if (packet.rfind("qThreadStopInfo", 0U) == 0U) {
+    if (!ensure_attached()) return err_packet(1);
+    size_t id_begin = std::strlen("qThreadStopInfo");
+    if (id_begin < packet.size() && packet[id_begin] == ',') ++id_begin;
+    if (id_begin >= packet.size()) return err_packet(1);
+    int32_t req_pid = 0, req_tid = 0;
+    if (!parse_thread_id(packet.c_str() + id_begin, req_pid, req_tid)) return err_packet(1);
+    if (req_pid > 0 && req_pid != pid_) return err_packet(1);
+    refresh_threads();
+    if (req_tid != pid_) {
+      const auto found = std::find_if(threads_.begin(), threads_.end(),
+                                      [&](const auto &thread) { return thread.lwp == req_tid; });
+      if (found == threads_.end()) return err_packet(1);
+    }
+    const int32_t saved = stop_lwp_;
+    stop_lwp_ = req_tid;
+    const std::string reply = stop_reply();
+    stop_lwp_ = saved;
+    return reply;
+  }
+  if (packet == "qfThreadInfo") {
+    refresh_threads();
+    thread_info_started_ = true;
+    if (threads_.empty()) {
+      if (pid_ > 0) {
+        char buf[16];
+        std::snprintf(buf, sizeof(buf), "m%x", static_cast<unsigned>(pid_));
+        return std::string(buf);
+      }
+      return "l";
+    }
+    std::string out = "m";
+    for (size_t i = 0; i < threads_.size(); ++i) {
+      if (i > 0U) out.push_back(',');
+      char buf[16];
+      std::snprintf(buf, sizeof(buf), "%x",
+                    static_cast<unsigned>(threads_[i].lwp > 0 ? threads_[i].lwp : pid_));
+      out += buf;
+    }
+    return out;
+  }
+  if (packet == "qsThreadInfo") return "l";
+  if (packet.rfind("qThreadExtraInfo,", 0) == 0) {
+    int32_t req_pid = 0, req_tid = 0;
+    if (!parse_thread_id(packet.c_str() + std::strlen("qThreadExtraInfo,"), req_pid, req_tid)) {
+      return err_packet(1);
+    }
+    refresh_threads();
+    for (const auto &t : threads_) {
+      if (t.lwp == req_tid || (req_tid <= 0 && t.lwp > 0)) {
+        return gdb_thread_extra_info_hex(t.lwp, t.name);
+      }
+    }
+    const int32_t fallback_tid = req_tid > 0 ? req_tid : (pid_ > 0 ? pid_ : 1);
+    return gdb_thread_extra_info_hex(fallback_tid, "");
+  }
+  std::string annex;
+  size_t offset = 0U, length = 0U;
+  if (packet.rfind("qXfer:features:read:", 0U) == 0U) {
+    if (!parse_qxfer_request(packet, "qXfer:features:read:", annex, offset, length))
+      return err_packet(1);
+    return qxfer_features(annex, offset, length);
+  }
+  if (packet.rfind("qXfer:memory-map:read:", 0U) == 0U) {
+    if (!parse_qxfer_request(packet, "qXfer:memory-map:read:", annex, offset, length) ||
+        !annex.empty())
+      return err_packet(1);
+    return qxfer_memory_map(offset, length);
+  }
+  if (packet.rfind("qXfer:threads:read:", 0U) == 0U) {
+    if (!parse_qxfer_request(packet, "qXfer:threads:read:", annex, offset, length) ||
+        !annex.empty())
+      return err_packet(1);
+    return qxfer_threads(offset, length);
+  }
+  if (packet.rfind("qXfer:libraries:read:", 0U) == 0U) {
+    if (!parse_qxfer_request(packet, "qXfer:libraries:read:", annex, offset, length) ||
+        !annex.empty())
+      return err_packet(1);
+    return qxfer_libraries(offset, length);
+  }
+  if (packet.rfind("qXfer:exec-file:read:", 0U) == 0U) {
+    if (!parse_qxfer_request(packet, "qXfer:exec-file:read:", annex, offset, length))
+      return err_packet(1);
+    if (!annex.empty()) {
+      uint64_t requested_pid = 0U;
+      if (!parse_hex_u64(annex, 0U, annex.size(), requested_pid) ||
+          requested_pid != static_cast<uint64_t>(pid_))
+        return err_packet(1);
+    }
+    return qxfer_exec_file(offset, length);
+  }
+  if (packet.rfind("qXfer:osdata:read:", 0U) == 0U) {
+    if (!parse_qxfer_request(packet, "qXfer:osdata:read:", annex, offset, length))
+      return err_packet(1);
+    return qxfer_osdata(annex, offset, length);
+  }
+  if (packet.rfind("qRcmd,", 0) == 0) {
+    /* Do not claim that an arbitrary monitor command ran when this target has
+     * no monitor-command channel.  An empty response is the RSP spelling for
+     * an unsupported query and lets GDB/IDA report it accurately. */
+    return std::string();
+  }
+  return std::string(); /* unsupported query */
+}
+
+} // namespace memdbg::gdb_bridge

--- a/tools/gdb_bridge/rsp_handler_registers.cpp
+++ b/tools/gdb_bridge/rsp_handler_registers.cpp
@@ -1,0 +1,94 @@
+/*
+ * MemDBG - GDB RSP register packet handling.
+ * Copyright (C) 2026 SeregonWar
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "rsp_handler.hpp"
+
+#include "gdb_regs.hpp"
+
+namespace memdbg::gdb_bridge {
+
+using namespace detail;
+
+std::string RspHandler::handle_read_all_registers() {
+  if (!ensure_attached()) return err_packet(1);
+  memdbg::frontend::Client::DebugRegs regs;
+  if (!backend_.debug_get_regs(current_thread(), regs)) return err_packet(1);
+
+  /* IDA matches the PS4 reference gdbsrv when g contains only the 24 amd64
+   * core registers. Optional x87/SSE state is available through p/P. */
+  return gdb_encode_g_core(regs.regs);
+}
+
+std::string RspHandler::handle_write_all_registers(const std::string &packet) {
+  if (!ensure_attached()) return err_packet(1);
+  memdbg::frontend::Client::DebugRegs regs;
+  if (!backend_.debug_get_regs(current_thread(), regs) ||
+      !gdb_decode_g_core(packet.substr(1U), regs.regs) ||
+      !backend_.debug_set_regs(current_thread(), regs)) {
+    return err_packet(1);
+  }
+  return "OK";
+}
+
+std::string RspHandler::handle_read_register(const std::string &packet) {
+  if (!ensure_attached()) return err_packet(1);
+  uint64_t regno = 0U;
+  if (!parse_hex_u64(packet.c_str() + 1U, regno) || !gdb_reg_valid(static_cast<int>(regno))) {
+    return err_packet(1);
+  }
+
+  const int ir = static_cast<int>(regno);
+  const size_t size = gdb_reg_size(ir);
+  if (gdb_reg_is_sse(ir) || gdb_reg_is_x87(ir)) {
+    memdbg::frontend::Client::DebugFpregs fpregs;
+    if (!backend_.debug_get_fpregs(current_thread(), fpregs)) return err_packet(1);
+    uint8_t buf[16]{};
+    const bool got = gdb_reg_is_sse(ir) ? gdb_get_sse_bytes(fpregs.fpregs, ir, buf, sizeof(buf))
+                                        : gdb_get_x87_bytes(fpregs.fpregs, ir, buf, sizeof(buf));
+    return got ? bytes_to_hex(buf, size) : err_packet(1);
+  }
+
+  memdbg::frontend::Client::DebugRegs regs;
+  if (!backend_.debug_get_regs(current_thread(), regs)) return err_packet(1);
+  uint64_t value = gdb_get_reg_value(regs.regs, ir);
+  if (size == 4U) value &= 0xFFFFFFFFULL;
+  return bytes_to_hex(&value, size);
+}
+
+std::string RspHandler::handle_write_register(const std::string &packet) {
+  if (!ensure_attached()) return err_packet(1);
+  const size_t eq = packet.find('=');
+  uint64_t regno = 0U;
+  if (eq == std::string::npos || !parse_hex_u64(packet, 1U, eq, regno) ||
+      !gdb_reg_valid(static_cast<int>(regno))) {
+    return err_packet(1);
+  }
+
+  const int ir = static_cast<int>(regno);
+  const size_t size = gdb_reg_size(ir);
+  if (gdb_reg_is_sse(ir) || gdb_reg_is_x87(ir)) {
+    uint8_t buf[16]{};
+    if (!hex_to_bytes(packet.substr(eq + 1U), buf, size)) return err_packet(1);
+    memdbg::frontend::Client::DebugFpregs fpregs;
+    if (!backend_.debug_get_fpregs(current_thread(), fpregs)) return err_packet(1);
+    const bool set = gdb_reg_is_sse(ir) ? gdb_set_sse_bytes(fpregs.fpregs, ir, buf, size)
+                                        : gdb_set_x87_bytes(fpregs.fpregs, ir, buf, size);
+    if (!set || !backend_.debug_set_fpregs(current_thread(), fpregs)) return err_packet(1);
+    return "OK";
+  }
+
+  uint64_t value = 0U;
+  memdbg::frontend::Client::DebugRegs regs;
+  if (!hex_to_bytes(packet.substr(eq + 1U), &value, size) ||
+      !backend_.debug_get_regs(current_thread(), regs) ||
+      !gdb_set_reg_value(regs.regs, ir, value) ||
+      !backend_.debug_set_regs(current_thread(), regs)) {
+    return err_packet(1);
+  }
+  return "OK";
+}
+
+} // namespace memdbg::gdb_bridge

--- a/tools/gdb_bridge/rsp_handler_run.cpp
+++ b/tools/gdb_bridge/rsp_handler_run.cpp
@@ -1,0 +1,266 @@
+/*
+ * MemDBG - GDB RSP execution and breakpoint handling.
+ * Copyright (C) 2026 SeregonWar
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "rsp_handler.hpp"
+
+#include "gdb_regs.hpp"
+
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <limits>
+#include <thread>
+
+namespace memdbg::gdb_bridge {
+
+using namespace detail;
+
+std::string RspHandler::handle_continue_or_step(bool step, RspConnection &conn, int32_t lwp) {
+  if (!ensure_attached()) return err_packet(1);
+
+  bool ok = false;
+  if (step) {
+    const int32_t tid = lwp != 0 ? lwp : current_thread();
+    logf("debug_step lwp=%d", static_cast<int>(tid));
+    ok = backend_.debug_step(tid);
+  } else {
+    logf("debug_continue");
+    ok = backend_.debug_continue();
+  }
+  if (!ok) {
+    logf("%s failed: %s", step ? "debug_step" : "debug_continue", backend_.last_error().c_str());
+    return err_packet(1);
+  }
+  stop_reason_.clear();
+
+  for (;;) {
+    if (conn.poll_interrupt(50U)) {
+      (void)backend_.debug_stop();
+      bool stopped = false;
+      int32_t stop_lwp = 0;
+      (void)backend_.debug_poll_events(stopped, stop_lwp);
+      if (stop_lwp != 0) stop_lwp_ = stop_lwp;
+      stop_signal_ = 2U;
+      (void)refresh_memory_maps();
+      return stop_reply();
+    }
+
+    bool stopped = false;
+    int32_t stop_lwp = 0;
+    if (!backend_.debug_poll_events(stopped, stop_lwp)) { return err_packet(1); }
+    if (stopped) {
+      if (stop_lwp != 0) stop_lwp_ = stop_lwp;
+      stop_signal_ = 5U;
+      refresh_threads();
+      for (const auto &thread : threads_) {
+        if (thread.lwp == stop_lwp_ && thread.stop_info.stop_signal > 0 &&
+            thread.stop_info.stop_signal <= 0xFF) {
+          stop_signal_ = static_cast<uint8_t>(thread.stop_info.stop_signal);
+          break;
+        }
+      }
+      capture_stop_reason(stop_lwp_);
+      general_thread_ = stop_lwp_;
+      /* The target may have loaded or unloaded modules while it was running.
+       * Keep range validation aligned with the new stopped state. */
+      (void)refresh_memory_maps();
+      return stop_reply();
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+  }
+}
+
+bool RspHandler::set_program_counter(uint64_t address) {
+  memdbg::frontend::Client::DebugRegs regs;
+  if (!backend_.debug_get_regs(current_thread(), regs)) return false;
+  regs.regs.r_rip = static_cast<int64_t>(address);
+  return backend_.debug_set_regs(current_thread(), regs);
+}
+
+bool RspHandler::kill_process(int32_t target_pid) {
+  if (target_pid <= 1) return false;
+  if (attached_) {
+    if (target_pid != pid_ || !safe_detach()) return false;
+  }
+  if (!backend_.process_kill(target_pid)) {
+    logf("process_kill failed for pid=%d: %s", static_cast<int>(target_pid),
+         backend_.last_error().c_str());
+    return false;
+  }
+  return true;
+}
+
+std::string RspHandler::handle_resume_packet(const std::string &packet, bool step,
+                                             RspConnection &conn) {
+  if (packet.empty()) return err_packet(1);
+  const bool with_signal = packet[0] == 'C' || packet[0] == 'S';
+  size_t address_begin = 1U;
+  if (with_signal) {
+    const size_t semi = packet.find(';', 1U);
+    const size_t signal_end = semi == std::string::npos ? packet.size() : semi;
+    uint64_t signal = 0U;
+    if (!parse_hex_u64(packet, 1U, signal_end, signal) || signal > 0xFFU) return err_packet(1);
+    if (semi == std::string::npos) return handle_continue_or_step(step, conn, continue_thread_);
+    address_begin = semi + 1U;
+  }
+
+  if (address_begin < packet.size()) {
+    uint64_t address = 0U;
+    if (!parse_hex_u64(packet, address_begin, packet.size(), address) || !ensure_attached() ||
+        !set_program_counter(address)) {
+      return err_packet(1);
+    }
+  }
+  return handle_continue_or_step(step, conn, continue_thread_);
+}
+
+std::string RspHandler::handle_breakpoint(const std::string &packet, bool enable) {
+  /* Ztype,addr,kind  / ztype,addr,kind */
+  if (!ensure_attached()) return err_packet(1);
+  if (packet.size() < 5U) return err_packet(1);
+  const char type = packet[1];
+  const size_t comma1 = packet.find(',', 2U);
+  if (comma1 == std::string::npos) return err_packet(1);
+  size_t comma2 = packet.find(',', comma1 + 1U);
+  if (comma2 == std::string::npos) comma2 = packet.size();
+  uint64_t addr = 0U;
+  uint64_t kind = 1U;
+  if (!parse_hex_u64(packet, comma1 + 1U, comma2, addr)) return err_packet(1);
+  if (comma2 < packet.size()) {
+    if (!parse_hex_u64(packet, comma2 + 1U, packet.size(), kind)) return err_packet(1);
+  }
+
+  if (type == '0') {
+    if (kind != 1U) return err_packet(0x22);
+    if (enable) {
+      if (!backend_.debug_set_breakpoint(addr, 0U)) return err_packet(1);
+    } else {
+      if (!backend_.debug_clear_breakpoint(addr)) return err_packet(1);
+    }
+    return "OK";
+  }
+  if (type == '1') {
+    if (kind != 1U) return err_packet(0x22);
+    if (enable) {
+      if (!backend_.debug_set_breakpoint(addr, 1U)) return err_packet(1);
+    } else {
+      if (!backend_.debug_clear_breakpoint(addr)) return err_packet(1);
+    }
+    return "OK";
+  }
+  const int wtype = watch_type_from_z(type);
+  if (wtype < 0) return std::string(); /* unsupported */
+  if (kind > std::numeric_limits<uint32_t>::max()) return err_packet(0x22);
+  const uint32_t length = kind == 0U ? 1U : static_cast<uint32_t>(kind);
+  if (length != 1U && length != 2U && length != 4U && length != 8U) return err_packet(0x22);
+  if (enable) {
+    if (!backend_.debug_set_watchpoint(addr, length, static_cast<uint32_t>(wtype))) {
+      return err_packet(1);
+    }
+  } else {
+    if (!backend_.debug_clear_watchpoint(addr)) return err_packet(1);
+  }
+  return "OK";
+}
+
+std::string RspHandler::handle_v(const std::string &packet, RspConnection &conn) {
+  if (packet.rfind("vAttach;", 0) == 0) {
+    int32_t req_pid = 0, req_tid = 0;
+    if (!parse_thread_id(packet.c_str() + 8, req_pid, req_tid)) {
+      logf("vAttach: bad pid hex in '%s'", packet.c_str());
+      return err_packet(1);
+    }
+    const int32_t attach_pid = req_pid > 0 ? req_pid : req_tid;
+    if (attach_pid <= 1) return err_packet(1);
+    logf("vAttach pid=0x%x (%d decimal)", static_cast<unsigned>(attach_pid),
+         static_cast<int>(attach_pid));
+    if (attached_ && pid_ == attach_pid) {
+      logf("vAttach: reusing session for pid=%d", static_cast<int>(pid_));
+      return stop_reply();
+    }
+    if (attached_) {
+      logf("vAttach: switching from pid=%d", static_cast<int>(pid_));
+      if (!safe_detach()) return err_packet(1);
+    }
+    pid_ = attach_pid;
+    if (!backend_.debug_attach(pid_)) {
+      logf("vAttach debug_attach failed: %s", backend_.last_error().c_str());
+      return err_packet(1);
+    }
+    attached_ = true;
+    refresh_threads();
+    if (!threads_.empty()) {
+      stop_lwp_ = threads_[0].lwp;
+      general_thread_ = stop_lwp_;
+    }
+    (void)refresh_memory_maps();
+    return stop_reply();
+  }
+  if (packet == "vCont?") { return "vCont;c;C;s;S"; }
+  if (packet.rfind("vKill;", 0U) == 0U) {
+    uint64_t requested_pid = 0U;
+    if (!parse_hex_u64(packet, 6U, packet.size(), requested_pid) ||
+        requested_pid > static_cast<uint64_t>(std::numeric_limits<int32_t>::max())) {
+      return err_packet(1);
+    }
+    return kill_process(static_cast<int32_t>(requested_pid)) ? "OK" : err_packet(1);
+  }
+  if (packet.rfind("vCont;", 0) == 0) {
+    /* MemDBG is all-stop: execute the first action, but validate every action
+     * so malformed per-thread tails cannot be silently ignored. */
+    char action = '\0';
+    int32_t lwp = 0;
+    size_t begin = 6U;
+    while (begin < packet.size()) {
+      const size_t end = packet.find(';', begin);
+      const std::string spec =
+        packet.substr(begin, end == std::string::npos ? std::string::npos : end - begin);
+      if (spec.empty()) return err_packet(1);
+      const char candidate = spec[0];
+      if (candidate != 'c' && candidate != 'C' && candidate != 's' && candidate != 'S') {
+        return err_packet(1);
+      }
+      int32_t candidate_lwp = 0;
+      const size_t colon = spec.find(':');
+      const size_t action_arg_end = colon == std::string::npos ? spec.size() : colon;
+      if (candidate == 'C' || candidate == 'S') {
+        uint64_t signal = 0U;
+        if (!parse_hex_u64(spec, 1U, action_arg_end, signal) || signal > 0xFFU) {
+          return err_packet(1);
+        }
+      } else if (action_arg_end != 1U) {
+        return err_packet(1);
+      }
+      if (colon != std::string::npos) {
+        int32_t p_out = 0, t_out = 0;
+        if (!parse_thread_id(spec.c_str() + colon + 1U, p_out, t_out) ||
+            (p_out > 0 && p_out != pid_)) {
+          return err_packet(1);
+        }
+        candidate_lwp = t_out > 0 ? t_out : 0;
+      }
+      if (action == '\0') {
+        action = candidate;
+        lwp = candidate_lwp;
+      } else if (lwp == 0 && candidate_lwp > 0) {
+        /* A thread-specific action overrides the all-thread default. */
+        action = candidate;
+        lwp = candidate_lwp;
+      }
+      if (end == std::string::npos) break;
+      if (end + 1U == packet.size()) return err_packet(1);
+      begin = end + 1U;
+    }
+    if (action == '\0') return err_packet(1);
+    if (action == 'c' || action == 'C') { return handle_continue_or_step(false, conn, lwp); }
+    if (action == 's' || action == 'S') { return handle_continue_or_step(true, conn, lwp); }
+    return err_packet(1);
+  }
+  if (packet == "vMustReplyEmpty") return std::string();
+  return std::string();
+}
+
+} // namespace memdbg::gdb_bridge

--- a/tools/gdb_bridge/rsp_protocol.cpp
+++ b/tools/gdb_bridge/rsp_protocol.cpp
@@ -1,0 +1,181 @@
+/*
+ * MemDBG - Shared GDB Remote Serial Protocol primitives.
+ * Copyright (C) 2026 SeregonWar
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "rsp_protocol.hpp"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
+#include <limits>
+
+namespace memdbg::gdb_bridge {
+namespace detail {
+
+bool parse_hex_u64(const std::string &s, size_t begin, size_t end, uint64_t &out) {
+  if (begin >= end || end > s.size()) return false;
+  uint64_t value = 0U;
+  for (size_t i = begin; i < end; ++i) {
+    const char c = s[i];
+    int n = -1;
+    if (c >= '0' && c <= '9')
+      n = c - '0';
+    else if (c >= 'a' && c <= 'f')
+      n = c - 'a' + 10;
+    else if (c >= 'A' && c <= 'F')
+      n = c - 'A' + 10;
+    else
+      return false;
+    if (value > (std::numeric_limits<uint64_t>::max() - static_cast<uint64_t>(n)) / 16U) {
+      return false;
+    }
+    value = value * 16U + static_cast<uint64_t>(n);
+  }
+  out = value;
+  return true;
+}
+
+bool parse_hex_u64(const char *s, uint64_t &out) {
+  if (s == nullptr || *s == '\0') return false;
+  const std::string text(s);
+  return parse_hex_u64(text, 0U, text.size(), out);
+}
+
+std::string err_packet(int code) {
+  char buf[8];
+  std::snprintf(buf, sizeof(buf), "E%02x", code & 0xFF);
+  return std::string(buf);
+}
+
+int watch_type_from_z(char kind) {
+  /* MemDBG: 0=exec, 1=write, 2=read, 3=rw */
+  switch (kind) {
+  case '1': return 0; /* hardware exec -> exec watch / HW BP uses set_breakpoint */
+  case '2': return 1;
+  case '3': return 2;
+  case '4': return 3;
+  default: return -1;
+  }
+}
+
+std::string xml_escape(const std::string &text) {
+  std::string out;
+  out.reserve(text.size());
+  for (char c : text) {
+    switch (c) {
+    case '&': out += "&amp;"; break;
+    case '<': out += "&lt;"; break;
+    case '>': out += "&gt;"; break;
+    case '\"': out += "&quot;"; break;
+    case '\'': out += "&apos;"; break;
+    default: out.push_back(c); break;
+    }
+  }
+  return out;
+}
+
+std::string qxfer_slice(const std::string &data, size_t offset, size_t length) {
+  if (length == 0U) return err_packet(1);
+  if (offset >= data.size()) return "l";
+  const size_t n = std::min(length, data.size() - offset);
+  std::string out(1U, offset + n >= data.size() ? 'l' : 'm');
+  out.append(data, offset, n);
+  return out;
+}
+
+bool parse_qxfer_request(const std::string &packet, const char *prefix, std::string &annex,
+                         size_t &offset, size_t &length) {
+  const size_t prefix_len = std::strlen(prefix);
+  if (packet.rfind(prefix, 0U) != 0U) return false;
+  const std::string rest = packet.substr(prefix_len);
+  const size_t colon = rest.find(':');
+  const size_t comma = colon == std::string::npos ? std::string::npos : rest.find(',', colon + 1U);
+  if (colon == std::string::npos || comma == std::string::npos) return false;
+  uint64_t parsed_offset = 0U;
+  uint64_t parsed_length = 0U;
+  if (!parse_hex_u64(rest, colon + 1U, comma, parsed_offset) ||
+      !parse_hex_u64(rest, comma + 1U, rest.size(), parsed_length) ||
+      parsed_offset > std::numeric_limits<size_t>::max() ||
+      parsed_length > std::numeric_limits<size_t>::max() || parsed_length == 0U) {
+    return false;
+  }
+  annex = rest.substr(0U, colon);
+  offset = static_cast<size_t>(parsed_offset);
+  length = static_cast<size_t>(parsed_length);
+  return true;
+}
+
+} // namespace detail
+
+using detail::parse_hex_u64;
+
+bool parse_thread_id(const char *s, int32_t &pid_out, int32_t &tid_out) {
+  if (s == nullptr || *s == '\0') return false;
+  const std::string text(s);
+  const bool multiprocess = text[0] == 'p';
+  const size_t first = multiprocess ? 1U : 0U;
+  if (first >= text.size()) return false;
+
+  auto parse_component = [&](size_t begin, size_t end, int32_t &value) {
+    if (begin >= end) return false;
+    if (end - begin == 2U && text.compare(begin, 2U, "-1") == 0) {
+      value = -1;
+      return true;
+    }
+    uint64_t parsed = 0U;
+    if (!parse_hex_u64(text, begin, end, parsed) ||
+        parsed > static_cast<uint64_t>(std::numeric_limits<int32_t>::max())) {
+      return false;
+    }
+    value = static_cast<int32_t>(parsed);
+    return true;
+  };
+
+  if (!multiprocess) {
+    pid_out = 0;
+    return parse_component(0U, text.size(), tid_out);
+  }
+
+  const size_t dot = text.find('.', first);
+  if (dot == std::string::npos || text.find('.', dot + 1U) != std::string::npos) return false;
+  return parse_component(first, dot, pid_out) && parse_component(dot + 1U, text.size(), tid_out);
+}
+
+std::string gdb_watchpoint_stop_field(
+  uint64_t dr6, const std::vector<memdbg::frontend::Client::DebugWatchpointEntry> &entries) {
+  const uint64_t hits = dr6 & 0xFULL;
+  for (const auto &entry : entries) {
+    if (!entry.installed || entry.slot >= 4U || (hits & (1ULL << entry.slot)) == 0U) { continue; }
+    if (entry.type == 0U) return "hwbreak:;";
+    const char *reason = entry.type == 1U ? "watch" : entry.type == 2U ? "rwatch" : "awatch";
+    char buf[64];
+    std::snprintf(buf, sizeof(buf), "%s:%llx;", reason,
+                  static_cast<unsigned long long>(entry.address));
+    return std::string(buf);
+  }
+  return std::string();
+}
+
+bool gdb_memory_range_mapped(const std::vector<memdbg::frontend::MapEntry> &maps, uint64_t address,
+                             uint64_t length) {
+  if (length == 0U) return true;
+  if (address > std::numeric_limits<uint64_t>::max() - length) return false;
+
+  const uint64_t request_end = address + length;
+  uint64_t cursor = address;
+  while (cursor < request_end) {
+    uint64_t covered_end = cursor;
+    for (const auto &map : maps) {
+      if (map.start <= cursor && cursor < map.end && map.end > covered_end) {
+        covered_end = map.end < request_end ? map.end : request_end;
+      }
+    }
+    if (covered_end == cursor) return false;
+    cursor = covered_end;
+  }
+  return true;
+}
+
+} // namespace memdbg::gdb_bridge

--- a/tools/gdb_bridge/rsp_protocol.hpp
+++ b/tools/gdb_bridge/rsp_protocol.hpp
@@ -1,0 +1,44 @@
+/*
+ * MemDBG - Shared GDB Remote Serial Protocol primitives.
+ * Copyright (C) 2026 SeregonWar
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef MEMDBG_GDB_BRIDGE_RSP_PROTOCOL_HPP
+#define MEMDBG_GDB_BRIDGE_RSP_PROTOCOL_HPP
+
+#include "memdbg_client.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace memdbg::gdb_bridge {
+
+bool parse_thread_id(const char *s, int32_t &pid_out, int32_t &tid_out);
+
+std::string gdb_watchpoint_stop_field(
+  uint64_t dr6, const std::vector<memdbg::frontend::Client::DebugWatchpointEntry> &entries);
+
+bool gdb_memory_range_mapped(const std::vector<memdbg::frontend::MapEntry> &maps, uint64_t address,
+                             uint64_t length);
+
+namespace detail {
+
+inline constexpr uint32_t kMemChunk = 0x10000U;
+inline constexpr uint64_t kRspMaxMemory = 0x100000U;
+
+bool parse_hex_u64(const std::string &s, size_t begin, size_t end, uint64_t &out);
+bool parse_hex_u64(const char *s, uint64_t &out);
+std::string err_packet(int code);
+int watch_type_from_z(char kind);
+std::string xml_escape(const std::string &text);
+std::string qxfer_slice(const std::string &data, size_t offset, size_t length);
+bool parse_qxfer_request(const std::string &packet, const char *prefix, std::string &annex,
+                         size_t &offset, size_t &length);
+
+} // namespace detail
+} // namespace memdbg::gdb_bridge
+
+#endif /* MEMDBG_GDB_BRIDGE_RSP_PROTOCOL_HPP */

--- a/tools/gdb_bridge/rsp_server.cpp
+++ b/tools/gdb_bridge/rsp_server.cpp
@@ -18,10 +18,14 @@
 namespace memdbg::gdb_bridge {
 
 namespace platform = memdbg::frontend::platform;
+namespace {
+constexpr size_t kMaxRspPacketBytes = 0x200000U;
+}
 
 uint8_t rsp_checksum(const std::string &payload) {
   unsigned sum = 0U;
-  for (unsigned char c : payload) sum = (sum + c) & 0xFFU;
+  for (unsigned char c : payload)
+    sum = (sum + c) & 0xFFU;
   return static_cast<uint8_t>(sum);
 }
 
@@ -39,18 +43,34 @@ std::string rsp_escape(const std::string &payload) {
   return out;
 }
 
+bool rsp_decode(const std::string &encoded, std::string &out) {
+  out.clear();
+  out.reserve(encoded.size());
+  for (size_t i = 0; i < encoded.size(); ++i) {
+    const unsigned char current = static_cast<unsigned char>(encoded[i]);
+    if (current == '}') {
+      if (i + 1U >= encoded.size()) return false;
+      out.push_back(static_cast<char>(static_cast<unsigned char>(encoded[++i]) ^ 0x20U));
+      continue;
+    }
+    if (current == '*') {
+      if (out.empty() || i + 1U >= encoded.size()) return false;
+      const unsigned char encoded_count = static_cast<unsigned char>(encoded[++i]);
+      if (encoded_count < 32U || encoded_count > 126U) return false;
+      const size_t repeat = static_cast<size_t>(encoded_count - 29U);
+      if (repeat > kMaxRspPacketBytes - out.size()) return false;
+      out.append(repeat, out.back());
+      continue;
+    }
+    out.push_back(static_cast<char>(current));
+    if (out.size() > kMaxRspPacketBytes) return false;
+  }
+  return true;
+}
+
 std::string rsp_unescape(const std::string &escaped) {
   std::string out;
-  out.reserve(escaped.size());
-  for (size_t i = 0; i < escaped.size(); ++i) {
-    if (escaped[i] == '}' && i + 1U < escaped.size()) {
-      out.push_back(static_cast<char>(static_cast<unsigned char>(escaped[i + 1U]) ^
-                                      0x20U));
-      ++i;
-    } else {
-      out.push_back(escaped[i]);
-    }
-  }
+  if (!rsp_decode(escaped, out)) return std::string();
   return out;
 }
 
@@ -88,17 +108,14 @@ int RspConnection::read_byte(uint32_t timeout_ms, bool *timed_out) {
     return static_cast<int>(c);
   }
 
-  if (timeout_ms > 0U) {
-    (void)platform::socket_set_recv_timeout(fd_, timeout_ms);
-  }
+  if (timeout_ms > 0U) { (void)platform::socket_set_recv_timeout(fd_, timeout_ms); }
 
   char ch = 0;
   const int n = platform::socket_recv(fd_, &ch, 1U);
   if (n == 1) return static_cast<unsigned char>(ch);
   if (n == 0) return -1;
   const int err = platform::socket_last_error_code();
-  if (platform::socket_error_would_block(err) ||
-      platform::socket_error_interrupted(err)) {
+  if (platform::socket_error_would_block(err) || platform::socket_error_interrupted(err)) {
     if (timed_out) *timed_out = true;
     return -2;
   }
@@ -124,6 +141,7 @@ RspPacket RspConnection::recv_packet() {
       if (c < 0) return packet;
       if (c == '#') break;
       body.push_back(static_cast<char>(c));
+      if (body.size() > kMaxRspPacketBytes) return packet;
     }
 
     const int c1 = read_byte(0U, nullptr);
@@ -147,8 +165,11 @@ RspPacket RspConnection::recv_packet() {
       if (!no_ack_) (void)send_ack(false);
       continue;
     }
+    if (!rsp_decode(body, packet.payload)) {
+      if (!no_ack_) (void)send_ack(false);
+      continue;
+    }
     if (!no_ack_) (void)send_ack(true);
-    packet.payload = rsp_unescape(body);
     packet.ok = true;
     return packet;
   }
@@ -199,14 +220,12 @@ RspServer::RspServer() : listen_fd_(platform::invalid_socket()) {}
 
 RspServer::~RspServer() { close_listen(); }
 
-bool RspServer::listen_on(const std::string &host, uint16_t port,
-                          std::string &error) {
+bool RspServer::listen_on(const std::string &host, uint16_t port, std::string &error) {
   close_listen();
 
   listen_fd_ = ::socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
   if (!platform::socket_valid(listen_fd_)) {
-    error = "socket() failed: " + platform::socket_error_text(
-                                      platform::socket_last_error_code());
+    error = "socket() failed: " + platform::socket_error_text(platform::socket_last_error_code());
     return false;
   }
   (void)platform::socket_set_reuse_addr(listen_fd_);
@@ -223,24 +242,20 @@ bool RspServer::listen_on(const std::string &host, uint16_t port,
     return false;
   }
 
-  if (::bind(listen_fd_, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) !=
-      0) {
-    error = "bind() failed: " + platform::socket_error_text(
-                                    platform::socket_last_error_code());
+  if (::bind(listen_fd_, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) != 0) {
+    error = "bind() failed: " + platform::socket_error_text(platform::socket_last_error_code());
     close_listen();
     return false;
   }
   if (::listen(listen_fd_, 1) != 0) {
-    error = "listen() failed: " + platform::socket_error_text(
-                                      platform::socket_last_error_code());
+    error = "listen() failed: " + platform::socket_error_text(platform::socket_last_error_code());
     close_listen();
     return false;
   }
 
   sockaddr_in bound{};
   platform::socklen_type len = sizeof(bound);
-  if (::getsockname(listen_fd_, reinterpret_cast<sockaddr *>(&bound), &len) ==
-      0) {
+  if (::getsockname(listen_fd_, reinterpret_cast<sockaddr *>(&bound), &len) == 0) {
     listen_port_ = ntohs(bound.sin_port);
   } else {
     listen_port_ = port;
@@ -263,10 +278,9 @@ platform::socket_handle_t RspServer::accept_client(std::string &error) {
   sockaddr_in peer{};
   platform::socklen_type len = sizeof(peer);
   platform::socket_handle_t client =
-      ::accept(listen_fd_, reinterpret_cast<sockaddr *>(&peer), &len);
+    ::accept(listen_fd_, reinterpret_cast<sockaddr *>(&peer), &len);
   if (!platform::socket_valid(client)) {
-    error = "accept() failed: " + platform::socket_error_text(
-                                      platform::socket_last_error_code());
+    error = "accept() failed: " + platform::socket_error_text(platform::socket_last_error_code());
     return platform::invalid_socket();
   }
   (void)platform::socket_set_nodelay(client);
@@ -274,8 +288,7 @@ platform::socket_handle_t RspServer::accept_client(std::string &error) {
   return client;
 }
 
-void RspServer::serve(platform::socket_handle_t client_fd,
-                      const Handler &handler) {
+void RspServer::serve(platform::socket_handle_t client_fd, const Handler &handler) {
   RspConnection conn(client_fd);
   for (;;) {
     RspPacket packet = conn.recv_packet();

--- a/tools/gdb_bridge/rsp_server.hpp
+++ b/tools/gdb_bridge/rsp_server.hpp
@@ -58,8 +58,7 @@ private:
 
 class RspServer {
 public:
-  using Handler = std::function<std::string(const std::string &packet,
-                                            RspConnection &conn)>;
+  using Handler = std::function<std::string(const std::string &packet, RspConnection &conn)>;
 
   RspServer();
   ~RspServer();
@@ -72,8 +71,7 @@ public:
 
   /* Serve packets until disconnect. Handler returns RSP payload (no $/#).
    * Empty string => empty OK packet. "E01" style errors are pass-through. */
-  void serve(memdbg::frontend::platform::socket_handle_t client_fd,
-             const Handler &handler);
+  void serve(memdbg::frontend::platform::socket_handle_t client_fd, const Handler &handler);
 
   uint16_t listen_port() const { return listen_port_; }
 
@@ -84,6 +82,7 @@ private:
 
 uint8_t rsp_checksum(const std::string &payload);
 std::string rsp_escape(const std::string &payload);
+bool rsp_decode(const std::string &encoded, std::string &out);
 std::string rsp_unescape(const std::string &escaped);
 
 } // namespace memdbg::gdb_bridge

--- a/tools/gdb_bridge/tests/test_gdb_bridge.cpp
+++ b/tools/gdb_bridge/tests/test_gdb_bridge.cpp
@@ -11,36 +11,203 @@
 
 #include <cstdio>
 #include <cstring>
+#include <limits>
 #include <string>
+#include <vector>
 
 using namespace memdbg::gdb_bridge;
 
 static int failures;
 
-#define CHECK(name, expr)                                                       \
-  do {                                                                          \
-    if (!(expr)) {                                                              \
-      std::fprintf(stderr, "FAIL: %s\n", name);                                 \
-      failures++;                                                               \
-    }                                                                           \
+#define CHECK(name, expr)                       \
+  do {                                          \
+    if (!(expr)) {                              \
+      std::fprintf(stderr, "FAIL: %s\n", name); \
+      failures++;                               \
+    }                                           \
   } while (0)
+
+class FakeRspBackend final : public RspBackend {
+public:
+  FakeRspBackend() : memory(0x2000U) {
+    for (size_t i = 0; i < memory.size(); ++i)
+      memory[i] = static_cast<uint8_t>(i & 0xFFU);
+    maps.push_back({0x1000U, 0x2000U, MEMDBG_MAP_PROT_READ | MEMDBG_MAP_PROT_EXEC, 0U,
+                    "/app0/eboot.bin", "image"});
+    maps.push_back({0x2000U, 0x3000U, MEMDBG_MAP_PROT_READ | MEMDBG_MAP_PROT_WRITE, 0U,
+                    "/app0/eboot.bin", "image"});
+    processes.push_back({0x49, 0x27, "eboot.bin"});
+    process_info_value.pid = 0x49;
+    process_info_value.name = "eboot.bin";
+    process_info_value.path = "/app0/eboot.bin";
+
+    memdbg::frontend::Client::DebugThreadEntry main_thread;
+    main_thread.lwp = 0x49;
+    main_thread.name = "main";
+    threads.push_back(main_thread);
+    memdbg::frontend::Client::DebugThreadEntry worker_thread;
+    worker_thread.lwp = 0x50;
+    worker_thread.name = "worker<&";
+    threads.push_back(worker_thread);
+
+    regs.regs.r_rip = 0x1010;
+    regs.regs.r_rsp = 0x2FF0;
+    regs.regs.r_rflags = 0x202;
+    fpregs.fpregs.length = 512U;
+    for (size_t i = 0; i < 10U; ++i)
+      fpregs.fpregs.data[kFxsaveSt0Off + i] = static_cast<uint8_t>(0xA0U + i);
+  }
+
+  std::string last_error() const override { return error; }
+  bool process_list(std::vector<memdbg::frontend::ProcessEntry> &out) override {
+    out = processes;
+    return true;
+  }
+  bool process_maps(int32_t, std::vector<memdbg::frontend::MapEntry> &out) override {
+    out = maps;
+    return maps_ok;
+  }
+  bool process_info(int32_t, memdbg::frontend::ProcessInfo &out) override {
+    out = process_info_value;
+    return true;
+  }
+  bool process_kill(int32_t pid) override {
+    killed_pid = pid;
+    attached = false;
+    return pid == 0x49;
+  }
+  bool memory_read(int32_t, uint64_t address, uint32_t length, std::vector<uint8_t> &out) override {
+    if (address < 0x1000U || address + length > 0x3000U) return false;
+    const size_t off = static_cast<size_t>(address - 0x1000U);
+    out.assign(memory.begin() + static_cast<std::ptrdiff_t>(off),
+               memory.begin() + static_cast<std::ptrdiff_t>(off + length));
+    return true;
+  }
+  bool memory_write(int32_t, uint64_t address, const std::vector<uint8_t> &data,
+                    uint32_t &written) override {
+    if (address < 0x1000U || address + data.size() > 0x3000U) return false;
+    const size_t off = static_cast<size_t>(address - 0x1000U);
+    std::copy(data.begin(), data.end(), memory.begin() + static_cast<std::ptrdiff_t>(off));
+    written = static_cast<uint32_t>(data.size());
+    return true;
+  }
+  bool debug_attach(int32_t pid) override {
+    attached = pid == 0x49;
+    return attached;
+  }
+  bool debug_detach() override {
+    attached = false;
+    detached = true;
+    return true;
+  }
+  bool debug_stop() override { return attached; }
+  bool debug_continue() override {
+    continued++;
+    return attached;
+  }
+  bool debug_step(int32_t lwp) override {
+    stepped_lwp = lwp;
+    return attached;
+  }
+  bool debug_get_threads(std::vector<memdbg::frontend::Client::DebugThreadEntry> &out) override {
+    out = threads;
+    return attached;
+  }
+  bool debug_get_regs(int32_t, memdbg::frontend::Client::DebugRegs &out) override {
+    out = regs;
+    return attached;
+  }
+  bool debug_set_regs(int32_t, const memdbg::frontend::Client::DebugRegs &in) override {
+    regs = in;
+    return attached;
+  }
+  bool debug_get_dbregs(int32_t, memdbg::frontend::Client::DebugDbregs &out) override {
+    out = dbregs;
+    return attached;
+  }
+  bool debug_get_fpregs(int32_t, memdbg::frontend::Client::DebugFpregs &out) override {
+    out = fpregs;
+    return attached;
+  }
+  bool debug_set_fpregs(int32_t, const memdbg::frontend::Client::DebugFpregs &in) override {
+    fpregs = in;
+    return attached;
+  }
+  bool debug_set_breakpoint(uint64_t address, uint32_t kind) override {
+    breakpoint_address = address;
+    breakpoint_kind = kind;
+    return attached;
+  }
+  bool debug_clear_breakpoint(uint64_t address) override {
+    breakpoint_address = address;
+    return attached;
+  }
+  bool debug_set_watchpoint(uint64_t address, uint32_t length, uint32_t type) override {
+    watchpoint = {address, length, type, 0U, true};
+    return attached;
+  }
+  bool debug_clear_watchpoint(uint64_t address) override {
+    watchpoint.address = address;
+    watchpoint.installed = false;
+    return attached;
+  }
+  bool
+  debug_get_watchpoints(std::vector<memdbg::frontend::Client::DebugWatchpointEntry> &out) override {
+    out.clear();
+    if (watchpoint.installed) out.push_back(watchpoint);
+    return attached;
+  }
+  bool debug_poll_events(bool &stopped, int32_t &stop_lwp) override {
+    stopped = true;
+    stop_lwp = 0x49;
+    return attached;
+  }
+
+  std::string error;
+  bool attached = false;
+  bool detached = false;
+  bool maps_ok = true;
+  int continued = 0;
+  int32_t stepped_lwp = 0;
+  int32_t killed_pid = 0;
+  uint64_t breakpoint_address = 0U;
+  uint32_t breakpoint_kind = 0U;
+  memdbg::frontend::Client::DebugWatchpointEntry watchpoint{};
+  memdbg::frontend::Client::DebugRegs regs{};
+  memdbg::frontend::Client::DebugDbregs dbregs{};
+  memdbg::frontend::Client::DebugFpregs fpregs{};
+  memdbg::frontend::ProcessInfo process_info_value;
+  std::vector<memdbg::frontend::ProcessEntry> processes;
+  std::vector<memdbg::frontend::MapEntry> maps;
+  std::vector<memdbg::frontend::Client::DebugThreadEntry> threads;
+  std::vector<uint8_t> memory;
+};
 
 int main() {
   /* Multiprocess RSP thread ID parser tests */
   int32_t pid_out = 0, tid_out = 0;
-  CHECK("parse_thread_id hex tid", parse_thread_id("4a", pid_out, tid_out) && pid_out == 0 && tid_out == 0x4A);
-  CHECK("parse_thread_id p4a.4a", parse_thread_id("p4a.4a", pid_out, tid_out) && pid_out == 0x4A && tid_out == 0x4A);
-  CHECK("parse_thread_id p4a.1001", parse_thread_id("p4a.1001", pid_out, tid_out) && pid_out == 0x4A && tid_out == 0x1001);
-  CHECK("parse_thread_id p-1.-1", parse_thread_id("p-1.-1", pid_out, tid_out) && pid_out == -1 && tid_out == -1);
+  CHECK("parse_thread_id hex tid",
+        parse_thread_id("4a", pid_out, tid_out) && pid_out == 0 && tid_out == 0x4A);
+  CHECK("parse_thread_id p4a.4a",
+        parse_thread_id("p4a.4a", pid_out, tid_out) && pid_out == 0x4A && tid_out == 0x4A);
+  CHECK("parse_thread_id p4a.1001",
+        parse_thread_id("p4a.1001", pid_out, tid_out) && pid_out == 0x4A && tid_out == 0x1001);
+  CHECK("parse_thread_id p-1.-1",
+        parse_thread_id("p-1.-1", pid_out, tid_out) && pid_out == -1 && tid_out == -1);
   CHECK("parse_thread_id -1", parse_thread_id("-1", pid_out, tid_out) && tid_out == -1);
+  CHECK("reject thread id trailing garbage", !parse_thread_id("49xyz", pid_out, tid_out));
+  CHECK("reject incomplete multiprocess thread id", !parse_thread_id("p49", pid_out, tid_out));
+  CHECK("reject overflowing thread id", !parse_thread_id("80000000", pid_out, tid_out));
   CHECK("checksum empty", rsp_checksum("") == 0U);
-  CHECK("checksum abc", rsp_checksum("abc") ==
-                            static_cast<uint8_t>('a' + 'b' + 'c'));
+  CHECK("checksum abc", rsp_checksum("abc") == static_cast<uint8_t>('a' + 'b' + 'c'));
 
   const std::string escaped = rsp_escape("a$#}b");
   CHECK("escape specials", escaped == "a}\x04}\x03}]b");
-  CHECK("unescape round-trip", rsp_unescape(rsp_escape("hello$#}")) ==
-                                   "hello$#}");
+  CHECK("unescape round-trip", rsp_unescape(rsp_escape("hello$#}")) == "hello$#}");
+  std::string decoded_rsp;
+  CHECK("decode RSP run-length encoding", rsp_decode("0* ", decoded_rsp) && decoded_rsp == "0000");
+  CHECK("reject dangling RSP escape", !rsp_decode("abc}", decoded_rsp));
+  CHECK("reject RSP repeat without prefix", !rsp_decode("* ", decoded_rsp));
 
   memdbg_debug_regs_t regs{};
   regs.r_rax = 0x1122334455667788LL;
@@ -68,11 +235,9 @@ int main() {
   regs.r_fs = 0x43U;
   regs.r_gs = 0x53U;
 
-  CHECK("rax mapping", gdb_get_reg_value(regs, GDB_RAX) ==
-                           0x1122334455667788ULL);
+  CHECK("rax mapping", gdb_get_reg_value(regs, GDB_RAX) == 0x1122334455667788ULL);
   CHECK("rip mapping", gdb_get_reg_value(regs, GDB_RIP) == 0x401000ULL);
-  CHECK("eflags truncated",
-        gdb_get_reg_value(regs, GDB_EFLAGS) == 0x246ULL);
+  CHECK("eflags truncated", gdb_get_reg_value(regs, GDB_EFLAGS) == 0x246ULL);
 
   const std::string g = gdb_encode_g_packet(regs, nullptr);
   /* core 328 + x87 padding 224 + xmm 512 + mxcsr 8 = 1072 hex chars (536 bytes) */
@@ -80,25 +245,17 @@ int main() {
 
   memdbg_debug_regs_t decoded{};
   CHECK("g decode succeeds", gdb_decode_g_packet(g, decoded, nullptr));
-  CHECK("rax round-trip",
-        static_cast<uint64_t>(decoded.r_rax) ==
-            0x1122334455667788ULL);
-  CHECK("rsp round-trip",
-        static_cast<uint64_t>(decoded.r_rsp) == 0x7FFFFFFFFULL);
-  CHECK("rip round-trip",
-        static_cast<uint64_t>(decoded.r_rip) == 0x401000ULL);
-  CHECK("rflags round-trip",
-        (static_cast<uint64_t>(decoded.r_rflags) & 0xFFFFFFFFULL) == 0x246ULL);
-  CHECK("ss round-trip",
-        static_cast<uint64_t>(decoded.r_ss) == 0x2BULL);
+  CHECK("rax round-trip", static_cast<uint64_t>(decoded.r_rax) == 0x1122334455667788ULL);
+  CHECK("rsp round-trip", static_cast<uint64_t>(decoded.r_rsp) == 0x7FFFFFFFFULL);
+  CHECK("rip round-trip", static_cast<uint64_t>(decoded.r_rip) == 0x401000ULL);
+  CHECK("rflags round-trip", (static_cast<uint64_t>(decoded.r_rflags) & 0xFFFFFFFFULL) == 0x246ULL);
+  CHECK("ss round-trip", static_cast<uint64_t>(decoded.r_ss) == 0x2BULL);
 
   const std::string ida_core = gdb_encode_g_core(regs);
   CHECK("IDA core g-packet size", ida_core.size() == 328U);
   memdbg_debug_regs_t ida_decoded{};
-  CHECK("IDA core g-packet decode",
-        gdb_decode_g_core(ida_core, ida_decoded));
-  CHECK("IDA core RIP round-trip",
-        static_cast<uint64_t>(ida_decoded.r_rip) == 0x401000ULL);
+  CHECK("IDA core g-packet decode", gdb_decode_g_core(ida_core, ida_decoded));
+  CHECK("IDA core RIP round-trip", static_cast<uint64_t>(ida_decoded.r_rip) == 0x401000ULL);
 
   memdbg_debug_fpregs_t fpregs{};
   fpregs.length = 512U;
@@ -107,8 +264,7 @@ int main() {
   CHECK("set xmm7", gdb_set_sse_bytes(fpregs, GDB_XMM7, xmm7, 16U));
   uint32_t mxcsr = 0x1F80U;
   CHECK("set mxcsr",
-        gdb_set_sse_bytes(fpregs, GDB_MXCSR,
-                          reinterpret_cast<const uint8_t *>(&mxcsr), 4U));
+        gdb_set_sse_bytes(fpregs, GDB_MXCSR, reinterpret_cast<const uint8_t *>(&mxcsr), 4U));
   const std::string g2 = gdb_encode_g_packet(regs, &fpregs);
   CHECK("g+sse size", g2.size() == 1072U);
   memdbg_debug_fpregs_t fpregs2{};
@@ -120,8 +276,7 @@ int main() {
 
   uint32_t mxcsr_out = 0;
   CHECK("get mxcsr",
-        gdb_get_sse_bytes(fpregs2, GDB_MXCSR,
-                          reinterpret_cast<uint8_t *>(&mxcsr_out), 4U));
+        gdb_get_sse_bytes(fpregs2, GDB_MXCSR, reinterpret_cast<uint8_t *>(&mxcsr_out), 4U));
   CHECK("mxcsr round-trip", mxcsr_out == 0x1F80U);
 
   /* xmm0 and xmm15 extremes */
@@ -141,13 +296,17 @@ int main() {
   memdbg_debug_fpregs_t short_fp{};
   short_fp.length = 32U;
   uint8_t zero16[16]{};
-  CHECK("short fxsave get xmm0 zeros",
-        gdb_get_sse_bytes(short_fp, GDB_XMM0, xmm0_out, 16U) &&
-            std::memcmp(xmm0_out, zero16, 16U) == 0);
-  CHECK("reject bad sse size",
-        !gdb_set_sse_bytes(fpregs, GDB_XMM0, xmm0, 8U));
-  CHECK("reject core as sse",
-        !gdb_set_sse_bytes(fpregs, GDB_RAX, xmm0, 16U));
+  CHECK("short fxsave get xmm0 zeros", gdb_get_sse_bytes(short_fp, GDB_XMM0, xmm0_out, 16U) &&
+                                         std::memcmp(xmm0_out, zero16, 16U) == 0);
+  CHECK("reject bad sse size", !gdb_set_sse_bytes(fpregs, GDB_XMM0, xmm0, 8U));
+  CHECK("reject core as sse", !gdb_set_sse_bytes(fpregs, GDB_RAX, xmm0, 16U));
+
+  const uint8_t st0[10] = {0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19};
+  CHECK("set x87 st0", gdb_set_x87_bytes(fpregs, GDB_ST0, st0, 10U));
+  uint8_t st0_out[10]{};
+  CHECK("get x87 st0", gdb_get_x87_bytes(fpregs, GDB_ST0, st0_out, sizeof(st0_out)) &&
+                         std::memcmp(st0, st0_out, sizeof(st0)) == 0);
+  CHECK("reject core as x87", !gdb_get_x87_bytes(fpregs, GDB_RAX, st0_out, sizeof(st0_out)));
 
   uint64_t patched = 0xDEADBEEFCAFEULL;
   CHECK("set rbx", gdb_set_reg_value(regs, GDB_RBX, patched));
@@ -160,34 +319,137 @@ int main() {
   CHECK("hex bytes match", back[0] == 0x01 && back[1] == 0x02 && back[2] == 0xFF);
 
   /* qThreadExtraInfo body: ASCII name hex-encoded for IDA/GDB. */
-  CHECK("thread extra named",
-        gdb_thread_extra_info_hex(88, "main") == "6d61696e");
+  CHECK("thread extra named", gdb_thread_extra_info_hex(88, "main") == "6d61696e");
   CHECK("thread extra empty fallback",
-        gdb_thread_extra_info_hex(0x58, "") ==
-            bytes_to_hex("LWP 88", 6U));
+        gdb_thread_extra_info_hex(0x58, "") == bytes_to_hex("LWP 88", 6U));
   CHECK("thread extra rejects non-text firmware fill",
-        gdb_thread_extra_info_hex(0x49, std::string(15U, '\xff')) ==
-            bytes_to_hex("LWP 73", 6U));
+        gdb_thread_extra_info_hex(0x49, std::string(15U, '\xff')) == bytes_to_hex("LWP 73", 6U));
   CHECK("thread extra rejects printable firmware fill",
-        gdb_thread_extra_info_hex(0x4A, "FFFFFFFFFFFFFFF") ==
-            bytes_to_hex("LWP 74", 6U));
+        gdb_thread_extra_info_hex(0x4A, "FFFFFFFFFFFFFFF") == bytes_to_hex("LWP 74", 6U));
 
   std::vector<memdbg::frontend::Client::DebugWatchpointEntry> watchpoints(3U);
   watchpoints[0] = {0x1000U, 4U, 1U, 0U, true};
   watchpoints[1] = {0x2000U, 4U, 2U, 1U, true};
   watchpoints[2] = {0x3000U, 8U, 3U, 2U, true};
-  CHECK("write DR6 stop reason",
-        gdb_watchpoint_stop_field(1ULL, watchpoints) == "watch:1000;");
-  CHECK("read DR6 stop reason",
-        gdb_watchpoint_stop_field(2ULL, watchpoints) == "rwatch:2000;");
-  CHECK("access DR6 stop reason",
-        gdb_watchpoint_stop_field(4ULL, watchpoints) == "awatch:3000;");
-  CHECK("no DR6 hit has no stop reason",
-        gdb_watchpoint_stop_field(0ULL, watchpoints).empty());
+  CHECK("write DR6 stop reason", gdb_watchpoint_stop_field(1ULL, watchpoints) == "watch:1000;");
+  CHECK("read DR6 stop reason", gdb_watchpoint_stop_field(2ULL, watchpoints) == "rwatch:2000;");
+  CHECK("access DR6 stop reason", gdb_watchpoint_stop_field(4ULL, watchpoints) == "awatch:3000;");
+  CHECK("no DR6 hit has no stop reason", gdb_watchpoint_stop_field(0ULL, watchpoints).empty());
+
+  std::vector<memdbg::frontend::MapEntry> maps;
+  maps.push_back({0x1000U, 0x1800U, 0U, 0U, "first", ""});
+  maps.push_back({0x1800U, 0x2000U, 0U, 0U, "second", ""});
+  maps.push_back({0x3000U, 0x4000U, 0U, 0U, "third", ""});
+  CHECK("mapped range within one mapping", gdb_memory_range_mapped(maps, 0x1100U, 0x100U));
+  CHECK("mapped range crosses adjacent mappings", gdb_memory_range_mapped(maps, 0x1700U, 0x200U));
+  CHECK("mapped zero-length range", gdb_memory_range_mapped(maps, 0x2500U, 0U));
+  CHECK("reject mapping gap", !gdb_memory_range_mapped(maps, 0x1F00U, 0x1200U));
+  CHECK("reject unmapped range", !gdb_memory_range_mapped(maps, 0x5000U, 0x100U));
+  CHECK("reject wrapping range",
+        !gdb_memory_range_mapped(maps, std::numeric_limits<uint64_t>::max() - 0x10U, 0x20U));
+
+  /* Full RSP command integration through a deterministic backend. */
+  FakeRspBackend fake;
+  RspHandler handler(fake, 0, false);
+  RspConnection conn(memdbg::frontend::platform::invalid_socket());
+
+  const std::string supported = handler.handle("qSupported:multiprocess+", conn);
+  CHECK("qSupported packet size is hexadecimal",
+        supported.find("PacketSize=200000") != std::string::npos);
+  CHECK("qSupported advertises thread XML",
+        supported.find("qXfer:threads:read+") != std::string::npos);
+  CHECK("qSupported advertises binary-safe features",
+        supported.find("vContSupported+") != std::string::npos);
+  CHECK("reject invalid attach pid", handler.handle("vAttach;1", conn) == "E01");
+  CHECK("attach by hexadecimal pid",
+        handler.handle("vAttach;49", conn) == "T05thread:49;" && fake.attached);
+  CHECK("attached query", handler.handle("qAttached", conn) == "1");
+  CHECK("current thread query", handler.handle("qC", conn) == "QC49");
+  CHECK("thread enumeration", handler.handle("qfThreadInfo", conn) == "m49,50");
+  CHECK("thread selection", handler.handle("Hg50", conn) == "OK");
+  CHECK("reject unknown thread", handler.handle("Hg999", conn) == "E01");
+  CHECK("thread name encoding",
+        handler.handle("qThreadExtraInfo,50", conn) == bytes_to_hex("worker<&", 8U));
+  CHECK("thread stop info", handler.handle("qThreadStopInfo50", conn) == "T05thread:50;");
+
+  const std::string thread_xml = handler.handle("qXfer:threads:read::0,1000", conn);
+  CHECK("thread XML final chunk", !thread_xml.empty() && thread_xml[0] == 'l');
+  CHECK("thread XML escapes names", thread_xml.find("worker&lt;&amp;") != std::string::npos);
+  const std::string library_xml = handler.handle("qXfer:libraries:read::0,1000", conn);
+  CHECK("library XML contains image", library_xml.find("/app0/eboot.bin") != std::string::npos);
+  CHECK("exec-file qXfer",
+        handler.handle("qXfer:exec-file:read:49:0,100", conn) == "l/app0/eboot.bin");
+  const std::string process_xml = handler.handle("qXfer:osdata:read:processes:0,1000", conn);
+  CHECK("process XML contains eboot", process_xml.find("eboot.bin") != std::string::npos);
+  CHECK("reject zero qXfer chunk",
+        handler.handle("qXfer:features:read:target.xml:0,0", conn) == "E01");
+
+  CHECK(
+    "mapped memory region info",
+    handler.handle("qMemoryRegionInfo:1000", conn).find("start:1000;size:1000;permissions:rx;") ==
+      0U);
+  CHECK("unmapped memory region info",
+        handler.handle("qMemoryRegionInfo:3000", conn).find("permissions:;") != std::string::npos);
+  CHECK("valid memory read", handler.handle("m1000,4", conn) == "00010203");
+  CHECK("reject unmapped memory read", handler.handle("m4000,4", conn) == "E01");
+  CHECK("reject oversized memory read", handler.handle("m1000,100001", conn) == "E22");
+  CHECK("reject wrapping memory read", handler.handle("mffffffffffffffff,2", conn) == "E22");
+  CHECK("hex memory write", handler.handle("M2004,4:aabbccdd", conn) == "OK" &&
+                              handler.handle("m2004,4", conn) == "aabbccdd");
+  CHECK("reject unmapped hex memory write", handler.handle("M4000,1:aa", conn) == "E01");
+  std::string binary_write = "X2008,4:";
+  binary_write.append("\x00\x23\x7d\xff", 4U);
+  CHECK("binary memory write", handler.handle(binary_write, conn) == "OK" &&
+                                 handler.handle("m2008,4", conn) == "00237dff");
+  CHECK("reject short binary write", handler.handle("X2008,4:abc", conn) == "E01");
+  CHECK("reject unmapped binary memory write", handler.handle("X4000,1:a", conn) == "E01");
+  CHECK("memory search found",
+        handler.handle(std::string("qSearch:memory:1000;100;") + std::string("\x20\x21\x22", 3U),
+                       conn) == "1,1020");
+  CHECK("memory search miss", handler.handle("qSearch:memory:1000;10;missing", conn) == "0");
+
+  CHECK("read RIP register", handler.handle("p10", conn) == "1010000000000000");
+  CHECK("read x87 register without stack overread",
+        handler.handle("p18", conn) == "a0a1a2a3a4a5a6a7a8a9");
+  CHECK("write x87 register", handler.handle("P18=10111213141516171819", conn) == "OK" &&
+                                handler.handle("p18", conn) == "10111213141516171819");
+  CHECK("write RIP register", handler.handle("P10=3412000000000000", conn) == "OK" &&
+                                static_cast<uint64_t>(fake.regs.regs.r_rip) == 0x1234U);
+  CHECK("reject malformed register number", handler.handle("p10junk", conn) == "E01");
+  CHECK("software breakpoint", handler.handle("Z0,1010,1", conn) == "OK" &&
+                                 fake.breakpoint_address == 0x1010U && fake.breakpoint_kind == 0U);
+  CHECK("reject invalid software breakpoint kind", handler.handle("Z0,1010,2", conn) == "E22");
+  CHECK("write watchpoint", handler.handle("Z2,2000,4", conn) == "OK" &&
+                              fake.watchpoint.installed && fake.watchpoint.type == 1U);
+  CHECK("reject invalid watchpoint length", handler.handle("Z2,2000,3", conn) == "E22");
+
+  CHECK("continue from explicit address", handler.handle("c1020", conn) == "T05thread:49;" &&
+                                            fake.continued == 1 &&
+                                            static_cast<uint64_t>(fake.regs.regs.r_rip) == 0x1020U);
+  CHECK("single step selected thread",
+        handler.handle("vCont;s:50", conn) == "T05thread:49;" && fake.stepped_lwp == 0x50);
+  CHECK("thread action overrides vCont default",
+        handler.handle("vCont;c;s:50", conn) == "T05thread:49;" && fake.stepped_lwp == 0x50);
+  CHECK("reject malformed vCont", handler.handle("vCont;Czz:49", conn) == "E01");
+  CHECK("reject malformed secondary vCont action",
+        handler.handle("vCont;c;invalid", conn) == "E01");
+  CHECK("reject trailing empty vCont action", handler.handle("vCont;c;", conn) == "E01");
+  CHECK("reject mismatched qAttached pid", handler.handle("qAttached:50", conn) == "0");
+  CHECK("unsupported monitor command is not reported as executed",
+        handler.handle("qRcmd,68656c70", conn).empty());
+  CHECK("reject malformed detach", handler.handle("Dgarbage", conn) == "E01" && handler.attached());
+  CHECK("detach", handler.handle("D", conn) == "OK" && fake.detached);
+  CHECK("detached query", handler.handle("qAttached", conn) == "0");
+  CHECK("reattach before vKill", handler.handle("vAttach;49", conn).find("T05thread:49;") == 0U);
+  CHECK("vKill process",
+        handler.handle("vKill;49", conn) == "OK" && fake.killed_pid == 0x49 && !handler.attached());
+  CHECK("reattach before legacy kill",
+        handler.handle("vAttach;49", conn).find("T05thread:49;") == 0U);
+  CHECK("legacy kill packet",
+        handler.handle("k", conn) == "OK" && fake.killed_pid == 0x49 && !handler.attached());
 
   CHECK("target xml non-empty", std::strlen(kMemdbgGdbTargetXml) > 100U);
-  CHECK("target xml has architecture",
-        std::strstr(kMemdbgGdbTargetXml, "i386:x86-64") != nullptr);
+  CHECK("target xml has architecture", std::strstr(kMemdbgGdbTargetXml, "i386:x86-64") != nullptr);
   CHECK("target xml uses IDA built-in register layout",
         std::strstr(kMemdbgGdbTargetXml, "<reg ") == nullptr);
 


### PR DESCRIPTION
## Summary

- split the monolithic RSP handler into focused query, memory, register, execution, protocol, and backend modules
- expand GDB/IDA RSP support for threads, XML transfers, memory operations, x87/SSE registers, process termination, and stop reporting
- harden packet parsing, mapped-range validation, framing, escaping, overflow handling, and unsupported-command behavior
- add a deterministic fake backend and broad end-to-end handler regression coverage
- update the English and Italian bridge documentation

## Root cause

The original bridge combined protocol framing, session state, packet parsing, register conversion, and backend access in one large handler. Several packet fields were parsed permissively, and x87 register reads could use an incorrect buffer width, producing the malformed register data reported in issue #39.

## Impact

GDB and IDA now receive stricter, more complete RSP behavior with explicit errors instead of truncation or false success. The modular backend boundary also makes future compatibility work testable without a live console.

## Validation

- `make test-gdb-bridge`
- ASan + UBSan `memdbg_gdb_bridge_test`
- `make test-debugger` (293/293)
- `make test-debugger-protocol` (145/145)
- debugger E2E handshake (live attach skipped on macOS because of ptrace restrictions)
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded GDB bridge support for thread and process queries, XML metadata, memory searches, binary memory writes, breakpoints, watchpoints, and process control.
  - Added comprehensive core, x87, and SSE register read/write support.
  - Added no-ack and non-stop protocol negotiation.
  - Added safer verbose packet logging and support for larger validated packets.

- **Bug Fixes**
  - Improved validation for malformed commands, invalid memory ranges, thread IDs, and register operations.
  - Stop responses now report the actual signal received.

- **Documentation**
  - Updated English and Italian bridge documentation with supported protocol features and source responsibilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->